### PR TITLE
Improve parsing pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,9 @@ com.dineth.debateTracker/
 │   ├── statistics/         # Output DTOs for stat endpoints
 │   ├── debaterprofiles/    # Debater profile sub-DTOs
 │   └── SpeakerTab/         # Speaker leaderboard DTOs
-├── utils/                  # StringUtil, RoundUtil, ProfileUtil, Constants, CustomExceptions
-├── TournamentBuilder.java  # Orchestrates XML parse → entity persistence (~32 KB, handle with care)
+├── utils/                  # StringUtil, RoundUtil, ProfileUtil, Constants, CustomExceptions, ParseTabbycatXML
+├── TournamentImportService.java  # The XML → entity persistence pipeline (one @Transactional import)
+├── TournamentBuilder.java        # Thin @RestController; resolves file paths and delegates to the import service
 └── DebateTrackerApplication.java
 ```
 
@@ -65,8 +66,9 @@ All entities carry `createdAt`/`updatedAt` managed by `@PrePersist`/`@PreUpdate`
 
 | File | Role |
 |---|---|
-| `TournamentBuilder.java` | Reads parsed DTOs and writes all entities to the DB; the main import pipeline |
-| `xmlparser/ParseTabbycatXML.java` | Deserializes Tabbycat XML into `dtos/xmlparsing/` DTOs |
+| `TournamentImportService.java` | Reads parsed DTOs and writes all entities to the DB; the main import pipeline (runs as one transaction) |
+| `TournamentBuilder.java` | `@RestController` for `/api/v1/tournament/*`; delegates to `TournamentImportService` |
+| `utils/ParseTabbycatXML.java` | Deserializes Tabbycat XML into `dtos/xmlparsing/` DTOs |
 | `statistics/StatisticsService.java` | Percentile ranks, win/loss ratios, judge sentiment |
 | `debaterprofile/DebaterProfileService.java` | Aggregates multi-tournament debater stats into a profile |
 | `judgeprofile/JudgeProfileService.java` | Aggregates judge activity and sentiment into a profile |
@@ -77,6 +79,19 @@ All entities carry `createdAt`/`updatedAt` managed by `@PrePersist`/`@PreUpdate`
 | `src/main/resources/application.properties` | DB URL, JPA DDL mode (`update`), API key |
 | `src/test/resources/application-test.properties` | H2, DDL `create-drop` |
 | `docs/TESTING.md` | Full testing guide — read this before writing tests |
+
+---
+
+## Import Pipeline
+
+`TournamentImportService.importTournament(filePath)` is one `@Transactional` method decomposed into small steps:
+
+1. Parse the XML into DTOs (`ParseTabbycatXML` — call `parseXML()` first, then the parameterless `getXxxDTOs()` accessors).
+2. Persist entities in dependency order: `saveInstitutions` → `saveJudges` → `saveTeams`/`saveDebaters` → tournament → `saveBreakCategories` → `saveMotions`.
+3. `buildLookupCaches` batch-loads judges/teams/motions/debaters into `Map<Long, Entity>` caches (keyed by db id) so the rounds loop never queries per debate.
+4. `processRound` → `buildDebate` builds debates/ballots from the caches; `buildDebate` returns `null` to skip a debate (unresolved teams or ballot-count mismatch).
+
+The whole method rolls back on any exception. XML-id→DTO maps (`debaterDTOMap`, etc.) are import-internal working state — they are **not** returned in `TournamentDataDTO`.
 
 ---
 
@@ -135,7 +150,7 @@ Three XML tournament fixtures live in `src/test/resources/`: `testTourney.xml` (
 - **Service transactions:** Complex multi-entity operations belong in a `@Transactional` service method.
 - **No business logic in controllers:** Controllers call one service method and return the result.
 - **Fuzzy matching for dedup:** `InstitutionService` and `ReplacementService` use Commons Text similarity — follow the same pattern for any new deduplication logic.
-- **Cascade:** Set cascade types deliberately; `TournamentBuilder` is the authoritative example of how related entities are linked during import.
+- **Cascade:** Set cascade types deliberately; `TournamentImportService` is the authoritative example of how related entities are linked during import.
 - **ID generation:** Use `@SequenceGenerator` + `@GeneratedValue` matching the existing pattern in any new entity.
 
 ---
@@ -148,7 +163,7 @@ Three XML tournament fixtures live in `src/test/resources/`: `testTourney.xml` (
 2. Create `<Entity>Repository.java` extending `JpaRepository`.
 3. Create `<Entity>Service.java` with `@Service`; inject the repository.
 4. Create `<Entity>Controller.java` with `@RestController`, `@RequestMapping("/api/v1/<resource>")`, and `@CrossOrigin(origins = "*")`.
-5. If the entity is imported from XML, add a corresponding DTO to `dtos/xmlparsing/` and wire it into `ParseTabbycatXML` and `TournamentBuilder`.
+5. If the entity is imported from XML, add a corresponding DTO to `dtos/xmlparsing/` and wire it into `ParseTabbycatXML` and `TournamentImportService`.
 
 ### Adding a new statistic
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,158 @@
+# Debate Tracker — Agent Reference
+
+A Spring Boot REST API that imports competitive debate tournament data exported from [Tabbycat](https://tabbycat.readthedocs.io/) (XML format), persists it to PostgreSQL, and exposes statistics and profile endpoints for debaters and judges.
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Language | Java 21 |
+| Framework | Spring Boot 4.0.0, Spring Data JPA |
+| Database (prod) | PostgreSQL 5432, `debatetracker` |
+| Database (test) | H2 in-memory |
+| Build | Maven 3.6+ |
+| Code gen | Lombok 1.18 |
+| XML parsing | Jackson Dataformat XML |
+| Statistics | Apache Commons Math 3 |
+| String matching | Apache Commons Text (fuzzy matching for dedup) |
+| Graph algorithms | JGraphT |
+| API docs | SpringDoc OpenAPI → `/swagger-ui.html` |
+
+---
+
+## Package Layout
+
+```
+com.dineth.debateTracker/
+├── <entity>/               # One package per domain entity
+│   ├── <Entity>.java       # JPA entity
+│   ├── <Entity>Repository.java
+│   ├── <Entity>Service.java
+│   └── <Entity>Controller.java
+├── dtos/
+│   ├── xmlparsing/         # DTOs that mirror Tabbycat XML structure
+│   ├── statistics/         # Output DTOs for stat endpoints
+│   ├── debaterprofiles/    # Debater profile sub-DTOs
+│   └── SpeakerTab/         # Speaker leaderboard DTOs
+├── utils/                  # StringUtil, RoundUtil, ProfileUtil, Constants, CustomExceptions
+├── TournamentBuilder.java  # Orchestrates XML parse → entity persistence (~32 KB, handle with care)
+└── DebateTrackerApplication.java
+```
+
+All controllers use `@CrossOrigin(origins = "*")` and are versioned under `/api/v1/<resource>`.
+
+---
+
+## Domain Model
+
+**14 entities.** Core relationships:
+
+- **Tournament** owns Rounds, Motions, and BreakCategories.
+- **Round** (prelim or elimination, tracked by `roundNo` and `isBreakRound`) owns Debates.
+- **Debate** links a proposition Team and opposition Team, records a winner, and owns Ballots/EliminationBallots.
+- **Ballot** records one judge's speaker score for one debater in one debate.
+- **Team** has a many-to-many with **Debater**. Debaters belong to an **Institution**.
+- **Judge/Adjudicator** is referenced by Ballots and Feedback.
+- **DebaterProfile** and **JudgeProfile** are computed aggregates (not raw relational data).
+
+All entities carry `createdAt`/`updatedAt` managed by `@PrePersist`/`@PreUpdate`. IDs use PostgreSQL sequences.
+
+---
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `TournamentBuilder.java` | Reads parsed DTOs and writes all entities to the DB; the main import pipeline |
+| `xmlparser/ParseTabbycatXML.java` | Deserializes Tabbycat XML into `dtos/xmlparsing/` DTOs |
+| `statistics/StatisticsService.java` | Percentile ranks, win/loss ratios, judge sentiment |
+| `debaterprofile/DebaterProfileService.java` | Aggregates multi-tournament debater stats into a profile |
+| `judgeprofile/JudgeProfileService.java` | Aggregates judge activity and sentiment into a profile |
+| `institution/InstitutionService.java` | Fuzzy-matches institution names to avoid duplicates |
+| `replacement/ReplacementService.java` | Merges duplicate debaters / judges across tournaments |
+| `utils/StringUtil.java` | Name normalization used throughout |
+| `utils/RoundUtil.java` | Round ordering and comparison |
+| `src/main/resources/application.properties` | DB URL, JPA DDL mode (`update`), API key |
+| `src/test/resources/application-test.properties` | H2, DDL `create-drop` |
+| `docs/TESTING.md` | Full testing guide — read this before writing tests |
+
+---
+
+## Build & Run
+
+```bash
+# Build
+mvn clean install
+
+# Run (requires local PostgreSQL with database 'debatetracker')
+mvn spring-boot:run
+
+# API docs
+open http://localhost:8080/swagger-ui.html
+```
+
+---
+
+## Tests
+
+Tests use H2 and the `test` Spring profile. No external services are needed.
+
+```bash
+# All tests
+mvn test
+
+# E2E tests only (full XML import → DB → assertions)
+mvn test -Dtest="*E2ETest"
+
+# Service unit tests only
+mvn test -Dtest="*ServiceTest"
+
+# Single test class
+mvn test -Dtest=TournamentDataE2ETest
+
+# Single test method
+mvn test -Dtest=TournamentDataE2ETest#testTournamentBasicDetails
+```
+
+### Test Infrastructure
+
+| Class | Purpose |
+|---|---|
+| `e2e/BaseE2ETest.java` | Loads XML fixtures and builds tournament; extend for E2E tests |
+| `builders/TestDataBuilder.java` | Fluent builder for constructing test entities in isolation |
+| `builders/TestFixtures.java` | Centralized expected values (counts, scores, names) for all three XML fixtures |
+
+Three XML tournament fixtures live in `src/test/resources/`: `testTourney.xml` (33 teams, 126 debaters, 47 judges, 9 rounds), `testTourney2.xml`, `testTourney3.xml`.
+
+---
+
+## Conventions
+
+- **Lombok everywhere:** Entities and DTOs use `@Getter`, `@Setter`, `@NoArgsConstructor`, `@AllArgsConstructor`. Avoid writing manual getters/setters.
+- **DTO separation:** Controllers return DTOs, never raw entities. Create a DTO in the appropriate `dtos/` sub-package.
+- **Service transactions:** Complex multi-entity operations belong in a `@Transactional` service method.
+- **No business logic in controllers:** Controllers call one service method and return the result.
+- **Fuzzy matching for dedup:** `InstitutionService` and `ReplacementService` use Commons Text similarity — follow the same pattern for any new deduplication logic.
+- **Cascade:** Set cascade types deliberately; `TournamentBuilder` is the authoritative example of how related entities are linked during import.
+- **ID generation:** Use `@SequenceGenerator` + `@GeneratedValue` matching the existing pattern in any new entity.
+
+---
+
+## Common Tasks
+
+### Adding a new entity
+
+1. Create `<Entity>.java` in a new package with `@Entity`, `@SequenceGenerator`, Lombok annotations, and `createdAt`/`updatedAt`.
+2. Create `<Entity>Repository.java` extending `JpaRepository`.
+3. Create `<Entity>Service.java` with `@Service`; inject the repository.
+4. Create `<Entity>Controller.java` with `@RestController`, `@RequestMapping("/api/v1/<resource>")`, and `@CrossOrigin(origins = "*")`.
+5. If the entity is imported from XML, add a corresponding DTO to `dtos/xmlparsing/` and wire it into `ParseTabbycatXML` and `TournamentBuilder`.
+
+### Adding a new statistic
+
+1. Add the calculation to `StatisticsService` (or `DebaterProfileService` / `JudgeProfileService` if profile-scoped).
+2. Create a DTO in `dtos/statistics/` or the relevant sub-package.
+3. Expose it via the appropriate existing controller or add a new endpoint.
+4. Add an E2E assertion in `ProfileAndStatisticsE2ETest` using values from `TestFixtures`.

--- a/src/main/java/com/dineth/debateTracker/TournamentBuilder.java
+++ b/src/main/java/com/dineth/debateTracker/TournamentBuilder.java
@@ -1,39 +1,12 @@
 package com.dineth.debateTracker;
 
-import com.dineth.debateTracker.ballot.Ballot;
-import com.dineth.debateTracker.ballot.BallotService;
-import com.dineth.debateTracker.breakcategory.BreakCategory;
-import com.dineth.debateTracker.breakcategory.BreakCategoryService;
-import com.dineth.debateTracker.debate.Debate;
-import com.dineth.debateTracker.debate.DebateService;
 import com.dineth.debateTracker.debater.Debater;
 import com.dineth.debateTracker.debater.DebaterService;
 import com.dineth.debateTracker.dtos.TournamentDataDTO;
-import com.dineth.debateTracker.dtos.xmlparsing.*;
-import com.dineth.debateTracker.eliminationballot.EliminationBallot;
-import com.dineth.debateTracker.eliminationballot.EliminationBallotService;
-import com.dineth.debateTracker.feedback.Feedback;
-import com.dineth.debateTracker.feedback.FeedbackService;
-import com.dineth.debateTracker.institution.Institution;
-import com.dineth.debateTracker.institution.InstitutionService;
-import com.dineth.debateTracker.judge.Judge;
-import com.dineth.debateTracker.judge.JudgeService;
-import com.dineth.debateTracker.motion.Motion;
-import com.dineth.debateTracker.motion.MotionService;
-import com.dineth.debateTracker.round.Round;
-import com.dineth.debateTracker.round.RoundService;
-import com.dineth.debateTracker.team.Team;
-import com.dineth.debateTracker.team.TeamService;
-import com.dineth.debateTracker.tournament.Tournament;
-import com.dineth.debateTracker.tournament.TournamentService;
-import com.dineth.debateTracker.utils.CustomExceptions;
+import com.dineth.debateTracker.dtos.xmlparsing.RoundDTO;
 import com.dineth.debateTracker.utils.ParseCSV;
-import com.dineth.debateTracker.utils.ParseTabbycatXML;
-import com.dineth.debateTracker.utils.StringUtil;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -42,14 +15,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
-import static com.dineth.debateTracker.utils.StringUtil.normalizeName;
-
+/**
+ * HTTP entry points for importing Tabbycat tournament XML. All persistence logic lives in
+ * {@link TournamentImportService}; this controller only resolves file paths and delegates.
+ */
 @RestController
 @Slf4j
 @CrossOrigin(origins = "*")
@@ -60,45 +31,20 @@ public class TournamentBuilder {
     private static final int DEFAULT_BUILD_YEAR = 2025;
     private static final int DEFAULT_SUMMARY_YEAR = 2024;
 
-    private final JudgeService judgeService;
-    private final TeamService teamService;
+    private final TournamentImportService importService;
     private final DebaterService debaterService;
-    private final DebateService debateService;
-    private final InstitutionService institutionService;
-    private final MotionService motionService;
-    private final TournamentService tournamentService;
-    private final BreakCategoryService breakCategoryService;
-    private final BallotService ballotService;
-    private final RoundService roundService;
-    private final FeedbackService feedbackService;
-    private final EliminationBallotService eliminationBallotService;
 
     @Autowired
-    public TournamentBuilder(JudgeService judgeService, TeamService teamService, DebaterService debaterService,
-            DebateService debateService, InstitutionService institutionService, MotionService motionService,
-            TournamentService tournamentService, BreakCategoryService breakCategoryService, BallotService ballotService,
-            RoundService roundService, FeedbackService feedbackService,
-            EliminationBallotService eliminationBallotService) {
-        this.judgeService = judgeService;
-        this.teamService = teamService;
+    public TournamentBuilder(TournamentImportService importService, DebaterService debaterService) {
+        this.importService = importService;
         this.debaterService = debaterService;
-        this.debateService = debateService;
-        this.institutionService = institutionService;
-        this.motionService = motionService;
-        this.tournamentService = tournamentService;
-        this.breakCategoryService = breakCategoryService;
-        this.ballotService = ballotService;
-        this.roundService = roundService;
-        this.feedbackService = feedbackService;
-        this.eliminationBallotService = eliminationBallotService;
     }
 
     @GetMapping("/build")
-    @Transactional
     public TournamentDataDTO buildTournament(@RequestParam String fileName,
             @RequestParam(required = false) Integer year) {
         int selectedYear = year != null ? year : DEFAULT_BUILD_YEAR;
-        return buildMyTournament(buildTournamentFilePath(fileName, selectedYear));
+        return importService.importTournament(buildTournamentFilePath(fileName, selectedYear));
     }
 
     @GetMapping("/buildall")
@@ -125,8 +71,7 @@ public class TournamentBuilder {
 
         for (String fileName : fileNames) {
             try {
-                TournamentDataDTO tournamentData = buildMyTournament(buildTournamentFilePath(fileName, selectedYear));
-                tournamentDataList.add(tournamentData);
+                tournamentDataList.add(importService.importTournament(buildTournamentFilePath(fileName, selectedYear)));
                 log.info("Built tournament : " + fileName);
             } catch (Exception e) {
                 log.error("Error building tournament " + fileName + ": " + e.getMessage(), e);
@@ -137,7 +82,6 @@ public class TournamentBuilder {
 
     @GetMapping("/parsecsv")
     public Object parseCSV() {
-
         List<Debater> debaters = new ParseCSV("src/main/resources/static/Debater_Information.csv").parseDebaterInfo();
         for (Debater debater : debaters) {
             try {
@@ -155,273 +99,6 @@ public class TournamentBuilder {
         return debaters;
     }
 
-    // Package-private for testing
-    @Transactional
-    TournamentDataDTO buildMyTournament(String filePath) {
-        try {
-            ParseTabbycatXML parser = new ParseTabbycatXML(filePath);
-            parser.parseXML();
-
-            TournamentDTO tournamentDTO = parser.getTournamentDTO(parser.document);
-            List<TeamDTO> teamDTOs = parser.getTeamDTOs(parser.document);
-            List<JudgeDTO> judgeDTOs = parser.getJudgeDTOs(parser.document);
-            List<InstitutionDTO> institutionDTOs = parser.getInstitutionDTOs(parser.document);
-            List<MotionDTO> motionDTOs = parser.getMotionDTOs(parser.document);
-            List<RoundDTO> roundsDTOs = parser.getRoundsDTO(parser.document);
-            List<BreakCategoryDTO> breakCategoryDTOs = parser.getBreakCategoryDTOs(parser.document);
-            HashMap<String, DebaterDTO> debaterDTOMap = new HashMap<>();
-            HashMap<String, TeamDTO> teamDTOMap = new HashMap<>();
-            HashMap<String, JudgeDTO> judgeDTOMap = new HashMap<>();
-
-            for (InstitutionDTO institutionDTO : institutionDTOs) {
-                Institution tempInstitution = institutionService.findInstitutionByName(institutionDTO.name.strip());
-                if (tempInstitution == null) {
-                    log.debug("Adding institution : " + institutionDTO.name);
-                    Institution institution = new Institution(institutionDTO.name.strip(), institutionDTO.reference);
-                    institution = institutionService.addInstitution(institution);
-                    institutionDTO.dbId = institution.getId();
-                } else {
-                    log.debug("Institution already exists : " + institutionDTO.name);
-                    institutionDTO.dbId = tempInstitution.getId();
-                }
-            }
-
-            for (JudgeDTO judgeDTO : judgeDTOs) {
-                ImmutablePair<String, String> names = StringUtil.splitName(judgeDTO.getName());
-                Judge judge = new Judge(judgeDTO.getScore(), names.getLeft(), names.getRight());
-                Judge existingJudge = judgeService.checkJudgeExists(judge);
-                if (existingJudge == null) {
-                    judge = judgeService.addJudge(judge);
-                } else {
-                    judge = existingJudge;
-                }
-                judgeDTO.setDbId(judge.getId());
-                judgeDTOMap.put(judgeDTO.getId(), judgeDTO);
-            }
-
-            for (TeamDTO teamDTO : teamDTOs) {
-                List<DebaterDTO> debaterDTOs = teamDTO.getDebaters();
-                List<Debater> debaters = debaterDTOs.stream().map(debaterDTO -> {
-                    ImmutablePair<String, String> names = StringUtil.splitName(debaterDTO.getName());
-                    Debater debater = new Debater(StringUtil.capitalizeName(names.getLeft()),
-                            StringUtil.capitalizeName(names.getRight()));
-                    Debater temp = debaterService.checkIfDebaterExists(debater);
-                    if (temp != null) {
-                        debater = temp;
-                    } else {
-                        debater = debaterService.addDebater(debater);
-                    }
-                    debaterDTO.setDbId(debater.getId());
-                    debaterDTOMap.put(debaterDTO.getId(), debaterDTO);
-                    return debater;
-                }).collect(Collectors.toList());
-                Team team = new Team(teamDTO.getName(), teamDTO.getCode(), debaters);
-                team = teamService.addTeam(team);
-                teamDTO.setDbId(team.getId());
-                teamDTOMap.put(teamDTO.getId(), teamDTO);
-                if (!debaterDTOs.isEmpty()) {
-                    String institutionId = debaterDTOs.get(0).getInstitutionId();
-                    if (institutionId == null || institutionId.isEmpty()) {
-                        log.debug("No institution ID found for team : " + teamDTO.getName());
-                        continue;
-                    }
-                    Institution institution = institutionDTOs.stream()
-                            .filter(inst -> inst.getId().equals(institutionId)).findFirst()
-                            .map(inst -> institutionService.findInstitutionById(inst.getDbId())).orElse(null);
-                    if (institution != null) {
-                        institutionService.addTeamToInstitution(institution.getId(), team);
-                    } else {
-                        log.debug("Institution not found for team : " + teamDTO.getName());
-                    }
-                } else {
-                    log.error("No debaters found for team : " + teamDTO.getName());
-                }
-            }
-
-            Tournament tournament = new Tournament(tournamentDTO.getFullName(), tournamentDTO.getShortName());
-            tournament = tournamentService.addTournament(tournament);
-
-            for (BreakCategoryDTO breakCategoryDTO : breakCategoryDTOs) {
-                BreakCategory breakCategory = new BreakCategory(breakCategoryDTO.getName());
-                breakCategory = breakCategoryService.addBreakCategory(breakCategory);
-                breakCategoryDTO.setDbId(breakCategory.getId());
-                tournamentService.addBreakCategoryToTournament(tournament.getId(), breakCategory);
-            }
-
-            for (MotionDTO motionDTO : motionDTOs) {
-                Motion motion = new Motion(normalizeName(motionDTO.getMotion()),
-                        normalizeName(motionDTO.getInfoSlide()), motionDTO.getReference());
-                motion = motionService.addMotion(motion);
-                motionDTO.setDbId(motion.getId());
-                tournamentService.addMotionToTournament(tournament.getId(), motion);
-            }
-
-            // Batch-load lookup caches to avoid per-debate queries inside the rounds loop
-            Map<Long, Judge> judgeCache = judgeService
-                    .findAllJudgesByIds(judgeDTOMap.values().stream()
-                            .map(JudgeDTO::getDbId).filter(Objects::nonNull).collect(Collectors.toSet()))
-                    .stream().collect(Collectors.toMap(Judge::getId, j -> j));
-
-            Map<Long, Team> teamCache = teamService
-                    .findAllTeamsByIds(teamDTOMap.values().stream()
-                            .map(TeamDTO::getDbId).filter(Objects::nonNull).collect(Collectors.toSet()))
-                    .stream().collect(Collectors.toMap(Team::getId, t -> t));
-
-            Map<Long, Motion> motionCache = motionService
-                    .findAllMotionsByIds(motionDTOs.stream()
-                            .map(MotionDTO::getDbId).filter(Objects::nonNull).collect(Collectors.toSet()))
-                    .stream().collect(Collectors.toMap(Motion::getId, m -> m));
-
-            Map<Long, Debater> debaterCache = debaterService
-                    .findAllDebatersByIds(debaterDTOMap.values().stream()
-                            .map(DebaterDTO::getDbId).filter(Objects::nonNull).collect(Collectors.toSet()))
-                    .stream().collect(Collectors.toMap(Debater::getId, d -> d));
-
-            for (RoundDTO roundDTO : roundsDTOs) {
-                Round round = new Round(roundDTO.getName(), null, roundDTO.isElimination());
-                round = roundService.addRound(round);
-                roundDTO.setDbId(round.getId());
-
-                for (DebateDTO debateDTO : roundDTO.getDebates()) {
-                    List<Judge> judges = new ArrayList<>();
-                    List<String> judgeIds = List.of(debateDTO.getAdjudicatorIds().split(" "));
-                    for (String judgeId : judgeIds) {
-                        JudgeDTO judgeDTO = judgeDTOMap.get(judgeId);
-                        Judge judge = judgeCache.get(judgeDTO.getDbId());
-                        if (judge != null) {
-                            judges.add(judge);
-                        }
-                    }
-
-                    Team prop = teamCache.get(teamDTOMap.get(debateDTO.getSides().get(0).getTeamId()).getDbId());
-                    Team opp = teamCache.get(teamDTOMap.get(debateDTO.getSides().get(1).getTeamId()).getDbId());
-
-                    if (prop == null || opp == null) {
-                        log.error("Skipping debate in round '{}': could not resolve proposition ({}) or opposition ({}) team",
-                                roundDTO.getName(),
-                                debateDTO.getSides().get(0).getTeamId(),
-                                debateDTO.getSides().get(1).getTeamId());
-                        continue;
-                    }
-
-                    String motionId = debateDTO.getMotionId();
-                    MotionDTO motionDTO = motionDTOs.stream().filter(m -> m.getId().equals(motionId))
-                            .findFirst().orElse(null);
-                    Motion motion = motionDTO != null ? motionCache.get(motionDTO.getDbId()) : null;
-
-                    int propBallots = debateDTO.getSides().get(0).getFinalTeamBallots().size();
-                    int oppBallots = debateDTO.getSides().get(1).getFinalTeamBallots().size();
-
-                    if (propBallots != oppBallots) {
-                        log.error("Skipping debate in round '{}': ballot count mismatch (prop={}, opp={})",
-                                roundDTO.getName(), propBallots, oppBallots);
-                        continue;
-                    }
-
-                    List<EliminationBallot> eliminationBallots = new ArrayList<>();
-                    if (roundDTO.isElimination()) {
-                        Team tempTeam1 = teamCache.get(teamDTOMap.get(debateDTO.getSides().get(0).getTeamId()).getDbId());
-                        Team tempTeam2 = teamCache.get(teamDTOMap.get(debateDTO.getSides().get(1).getTeamId()).getDbId());
-                        if (tempTeam1 == null || tempTeam2 == null) {
-                            log.error("Skipping elimination ballot in round '{}': could not resolve teams", roundDTO.getName());
-                        } else {
-                            for (SideDTO sideDTO : debateDTO.getSides()) {
-                                Team currentTeam = teamCache.get(teamDTOMap.get(sideDTO.getTeamId()).getDbId());
-                                for (FinalTeamBallotDTO finalTeamBallotDTO : sideDTO.getFinalTeamBallots()) {
-                                    String judgeId = finalTeamBallotDTO.getAdjudicatorIds().get(0);
-                                    Judge judge = judgeCache.get(judgeDTOMap.get(judgeId).getDbId());
-                                    if (finalTeamBallotDTO.getRank() == 1 && currentTeam.getId().equals(tempTeam1.getId())) {
-                                        eliminationBallots.add(new EliminationBallot(judge, tempTeam1, tempTeam2));
-                                    } else if (finalTeamBallotDTO.getRank() == 1 && currentTeam.getId().equals(tempTeam2.getId())) {
-                                        eliminationBallots.add(new EliminationBallot(judge, tempTeam2, tempTeam1));
-                                    }
-                                }
-                            }
-                            for (EliminationBallot eliminationBallot : eliminationBallots) {
-                                eliminationBallotService.addEliminationBallot(eliminationBallot);
-                            }
-                        }
-                    }
-
-                    List<String> ignoredBallotAdjIds = new ArrayList<>();
-                    List<FinalTeamBallotDTO> adjBallots = debateDTO.getSides().get(0).getFinalTeamBallots();
-                    for (FinalTeamBallotDTO adjBallot : adjBallots) {
-                        if (adjBallot.isIgnored()) {
-                            ignoredBallotAdjIds.addAll(adjBallot.getAdjudicatorIds());
-                        }
-                    }
-
-                    List<Ballot> ballots = new ArrayList<>();
-                    if (!roundDTO.isElimination()) {
-                        for (SideDTO sideDTO : debateDTO.getSides()) {
-                            for (SpeechDTO speechDTO : sideDTO.getSpeeches()) {
-                                for (IndividualSpeechBallotDTO individualSpeechBallotDTO : speechDTO.getIndividualSpeechBallots()) {
-                                    String judgeId = individualSpeechBallotDTO.getAdjudicatorId();
-                                    String debaterId = speechDTO.getSpeakerId();
-                                    double score = individualSpeechBallotDTO.getScore();
-
-                                    if (ignoredBallotAdjIds.contains(judgeId)) {
-                                        continue;
-                                    }
-                                    //judgeId may contain multiple adjudicators, take the first one (chair)
-                                    judgeId = judgeId.split(" ")[0];
-                                    Judge judge = judgeCache.get(judgeDTOMap.get(judgeId).getDbId());
-                                    Debater debater = debaterCache.get(debaterDTOMap.get(debaterId).getDbId());
-                                    if (judge != null && debater != null) {
-                                        Ballot ballot = new Ballot(judge, debater, (float) score, speechDTO.getSpeakerPosition());
-                                        ballotService.addBallot(ballot);
-                                        ballots.add(ballot);
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    Debate debate;
-                    if (roundDTO.isElimination()) {
-                        debate = new Debate(prop, opp, null, null, motion);
-                        debate.setEliminationBallots(eliminationBallots);
-                        if (eliminationBallots.size() == 1) {
-                            debate.setWinner(eliminationBallots.get(0).getWinner());
-                        } else {
-                            long propWins = eliminationBallots.stream()
-                                    .filter(b -> b.getWinner().equals(prop)).count();
-                            long oppWins = eliminationBallots.size() - propWins;
-                            debate.setWinner(propWins > oppWins ? prop : opp);
-                        }
-                    } else {
-                        debate = new Debate(prop, opp, null, ballots, motion);
-                        String side0TeamId = debateDTO.getSides().get(0).getTeamId();
-                        String side1TeamId = debateDTO.getSides().get(1).getTeamId();
-                        Team side0Team = teamCache.get(teamDTOMap.get(side0TeamId).getDbId());
-                        Team side1Team = teamCache.get(teamDTOMap.get(side1TeamId).getDbId());
-                        long side0Wins = debateDTO.getSides().get(0).getFinalTeamBallots().stream()
-                                .filter(b -> b.getRank() == 1).count();
-                        long side1Wins = debateDTO.getSides().get(1).getFinalTeamBallots().stream()
-                                .filter(b -> b.getRank() == 1).count();
-                        if (side0Wins > side1Wins) {
-                            debate.setWinner(side0Team);
-                        } else if (side0Wins < side1Wins) {
-                            debate.setWinner(side1Team);
-                        }
-                    }
-                    debate = debateService.addDebate(debate);
-                    roundService.addDebateToRound(round.getId(), debate);
-                }
-                tournamentService.addRoundToTournament(tournament.getId(), round);
-            }
-
-            log.debug("Feedback processing skipped (disabled for test environment compatibility)");
-
-            return new TournamentDataDTO(tournamentDTO,
-                    new ArrayList<>(debaterDTOMap.values()), teamDTOs, judgeDTOs, institutionDTOs, motionDTOs,
-                    breakCategoryDTOs, roundsDTOs, debaterDTOMap, teamDTOMap, judgeDTOMap);
-        } catch (Exception e) {
-            log.error("Error in building tournament : " + e.getMessage(), e);
-            throw new RuntimeException("Tournament build failed: " + e.getMessage(), e);
-        }
-    }
-
     /**
      * Get tournament data summary - useful for checking what data was parsed
      */
@@ -431,7 +108,7 @@ public class TournamentBuilder {
         int selectedYear = year != null ? year : DEFAULT_SUMMARY_YEAR;
         TournamentDataDTO tournamentData;
         try {
-            tournamentData = buildMyTournament(buildTournamentFilePath(fileName, selectedYear));
+            tournamentData = importService.importTournament(buildTournamentFilePath(fileName, selectedYear));
         } catch (Exception e) {
             return "Failed to build tournament data: " + e.getMessage();
         }

--- a/src/main/java/com/dineth/debateTracker/TournamentBuilder.java
+++ b/src/main/java/com/dineth/debateTracker/TournamentBuilder.java
@@ -44,6 +44,8 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.dineth.debateTracker.utils.StringUtil.normalizeName;
@@ -100,7 +102,6 @@ public class TournamentBuilder {
     }
 
     @GetMapping("/buildall")
-    @Transactional
     public List<TournamentDataDTO> buildAllTournaments(@RequestParam(required = false) Integer year) {
         List<String> fileNames = new ArrayList<>();
         List<TournamentDataDTO> tournamentDataList = new ArrayList<>();
@@ -125,9 +126,7 @@ public class TournamentBuilder {
         for (String fileName : fileNames) {
             try {
                 TournamentDataDTO tournamentData = buildMyTournament(buildTournamentFilePath(fileName, selectedYear));
-                if (tournamentData != null) {
-                    tournamentDataList.add(tournamentData);
-                }
+                tournamentDataList.add(tournamentData);
                 log.info("Built tournament : " + fileName);
             } catch (Exception e) {
                 log.error("Error building tournament " + fileName + ": " + e.getMessage(), e);
@@ -157,7 +156,7 @@ public class TournamentBuilder {
     }
 
     // Package-private for testing
-    @Transactional(noRollbackFor = Exception.class)
+    @Transactional
     TournamentDataDTO buildMyTournament(String filePath) {
         try {
             ParseTabbycatXML parser = new ParseTabbycatXML(filePath);
@@ -174,365 +173,252 @@ public class TournamentBuilder {
             HashMap<String, TeamDTO> teamDTOMap = new HashMap<>();
             HashMap<String, JudgeDTO> judgeDTOMap = new HashMap<>();
 
-            //save debaters, institutions, judges, motions, teams
-
             for (InstitutionDTO institutionDTO : institutionDTOs) {
-                try {
-                    //  check if institution exists
-                    Institution tempInstitution = institutionService.findInstitutionByName(institutionDTO.name.strip());
-                    if (tempInstitution == null) {
-                        log.debug("Adding institution : " + institutionDTO.name);
-                        Institution institution = new Institution(institutionDTO.name.strip(),
-                                institutionDTO.reference);
-                        institution = institutionService.addInstitution(institution);
-                        institutionDTO.dbId = institution.getId();
-                    } else {
-                        log.debug("Institution already exists : " + institutionDTO.name);
-                        institutionDTO.dbId = tempInstitution.getId();
-                    }
-                } catch (Exception e) {
-                    log.error("Error in adding institution '" + institutionDTO.name + "': " + e.getMessage(), e);
+                Institution tempInstitution = institutionService.findInstitutionByName(institutionDTO.name.strip());
+                if (tempInstitution == null) {
+                    log.debug("Adding institution : " + institutionDTO.name);
+                    Institution institution = new Institution(institutionDTO.name.strip(), institutionDTO.reference);
+                    institution = institutionService.addInstitution(institution);
+                    institutionDTO.dbId = institution.getId();
+                } else {
+                    log.debug("Institution already exists : " + institutionDTO.name);
+                    institutionDTO.dbId = tempInstitution.getId();
                 }
             }
 
-            try {
-                for (JudgeDTO judgeDTO : judgeDTOs) {
-                    ImmutablePair<String, String> names = StringUtil.splitName(judgeDTO.getName());
-                    Judge judge = new Judge(judgeDTO.getScore(), names.getLeft(), names.getRight());
-                    Judge existingJudge = judgeService.checkJudgeExists(judge);
-                    if (existingJudge == null) {
-                        judge = judgeService.addJudge(judge);
-                    } else {
-                        judge = existingJudge;
-                    }
-                    judgeDTO.setDbId(judge.getId());
-                    judgeDTOMap.put(judgeDTO.getId(), judgeDTO);
+            for (JudgeDTO judgeDTO : judgeDTOs) {
+                ImmutablePair<String, String> names = StringUtil.splitName(judgeDTO.getName());
+                Judge judge = new Judge(judgeDTO.getScore(), names.getLeft(), names.getRight());
+                Judge existingJudge = judgeService.checkJudgeExists(judge);
+                if (existingJudge == null) {
+                    judge = judgeService.addJudge(judge);
+                } else {
+                    judge = existingJudge;
                 }
-            } catch (CustomExceptions.NameSplitException e) {
-                log.error("Error in splitting name : " + e.getMessage());
-            } catch (Exception e) {
-                log.error("Error in adding judge : " + e.getMessage(), e);
+                judgeDTO.setDbId(judge.getId());
+                judgeDTOMap.put(judgeDTO.getId(), judgeDTO);
             }
 
-            try {
-                for (TeamDTO teamDTO : teamDTOs) {
-                    List<DebaterDTO> debaterDTOs = teamDTO.getDebaters();
-                    List<Debater> debaters = debaterDTOs.stream().map(debaterDTO -> {
-                        ImmutablePair<String, String> names = StringUtil.splitName(debaterDTO.getName());
-                        Debater debater = new Debater(StringUtil.capitalizeName(names.getLeft()),
-                                StringUtil.capitalizeName(names.getRight()));
-                        //TODO check for user confirmation
-                        Debater temp = debaterService.checkIfDebaterExists(debater);
-                        if (temp != null) {
-                            debater = temp;
-                        } else {
-                            debater = debaterService.addDebater(debater);
-                        }
-                        debaterDTO.setDbId(debater.getId());
-                        debaterDTOMap.put(debaterDTO.getId(), debaterDTO);
-                        return debater;
-                    }).collect(Collectors.toList());
-                    Team team = new Team(teamDTO.getName(), teamDTO.getCode(), debaters);
-                    team = teamService.addTeam(team);
-                    teamDTO.setDbId(team.getId());
-                    teamDTOMap.put(teamDTO.getId(), teamDTO);
-                    //                    Get the institution of one debater in the team and add the team to the institution
-                    if (!debaterDTOs.isEmpty()) {
-                        String institutionId = debaterDTOs.get(0).getInstitutionId();
-                        if (institutionId == null || institutionId.isEmpty()) {
-                            log.debug("No institution ID found for team : " + teamDTO.getName());
-                            continue;
-                        }
-                        Institution institution = institutionDTOs.stream()
-                                .filter(inst -> inst.getId().equals(institutionId)).findFirst()
-                                .map(inst -> institutionService.findInstitutionById(inst.getDbId())).orElse(null);
-                        if (institution != null) {
-                            institutionService.addTeamToInstitution(institution.getId(), team);
-                        } else {
-                            log.debug("Institution not found for team : " + teamDTO.getName());
-                        }
+            for (TeamDTO teamDTO : teamDTOs) {
+                List<DebaterDTO> debaterDTOs = teamDTO.getDebaters();
+                List<Debater> debaters = debaterDTOs.stream().map(debaterDTO -> {
+                    ImmutablePair<String, String> names = StringUtil.splitName(debaterDTO.getName());
+                    Debater debater = new Debater(StringUtil.capitalizeName(names.getLeft()),
+                            StringUtil.capitalizeName(names.getRight()));
+                    Debater temp = debaterService.checkIfDebaterExists(debater);
+                    if (temp != null) {
+                        debater = temp;
                     } else {
-                        log.error("No debaters found for team : " + teamDTO.getName());
+                        debater = debaterService.addDebater(debater);
                     }
+                    debaterDTO.setDbId(debater.getId());
+                    debaterDTOMap.put(debaterDTO.getId(), debaterDTO);
+                    return debater;
+                }).collect(Collectors.toList());
+                Team team = new Team(teamDTO.getName(), teamDTO.getCode(), debaters);
+                team = teamService.addTeam(team);
+                teamDTO.setDbId(team.getId());
+                teamDTOMap.put(teamDTO.getId(), teamDTO);
+                if (!debaterDTOs.isEmpty()) {
+                    String institutionId = debaterDTOs.get(0).getInstitutionId();
+                    if (institutionId == null || institutionId.isEmpty()) {
+                        log.debug("No institution ID found for team : " + teamDTO.getName());
+                        continue;
+                    }
+                    Institution institution = institutionDTOs.stream()
+                            .filter(inst -> inst.getId().equals(institutionId)).findFirst()
+                            .map(inst -> institutionService.findInstitutionById(inst.getDbId())).orElse(null);
+                    if (institution != null) {
+                        institutionService.addTeamToInstitution(institution.getId(), team);
+                    } else {
+                        log.debug("Institution not found for team : " + teamDTO.getName());
+                    }
+                } else {
+                    log.error("No debaters found for team : " + teamDTO.getName());
                 }
-            } catch (Exception e) {
-                log.error("Error in adding team : " + e.getMessage(), e);
             }
 
             Tournament tournament = new Tournament(tournamentDTO.getFullName(), tournamentDTO.getShortName());
             tournament = tournamentService.addTournament(tournament);
 
-            try {
-                for (BreakCategoryDTO breakCategoryDTO : breakCategoryDTOs) {
-                    BreakCategory breakCategory = new BreakCategory(breakCategoryDTO.getName());
-                    breakCategory = breakCategoryService.addBreakCategory(breakCategory);
-                    breakCategoryDTO.setDbId(breakCategory.getId());
-                    tournamentService.addBreakCategoryToTournament(tournament.getId(), breakCategory);
-                }
-            } catch (Exception e) {
-                log.error("Error in adding break category : " + e.getMessage(), e);
+            for (BreakCategoryDTO breakCategoryDTO : breakCategoryDTOs) {
+                BreakCategory breakCategory = new BreakCategory(breakCategoryDTO.getName());
+                breakCategory = breakCategoryService.addBreakCategory(breakCategory);
+                breakCategoryDTO.setDbId(breakCategory.getId());
+                tournamentService.addBreakCategoryToTournament(tournament.getId(), breakCategory);
             }
-            try {
-                for (MotionDTO motionDTO : motionDTOs) {
-                    Motion motion = new Motion(normalizeName(motionDTO.getMotion()),
-                            normalizeName(motionDTO.getInfoSlide()), motionDTO.getReference());
-                    motion = motionService.addMotion(motion);
-                    motionDTO.setDbId(motion.getId());
-                    tournamentService.addMotionToTournament(tournament.getId(), motion);
-                }
-            } catch (Exception e) {
-                log.error("Error in adding motion : " + e.getMessage(), e);
+
+            for (MotionDTO motionDTO : motionDTOs) {
+                Motion motion = new Motion(normalizeName(motionDTO.getMotion()),
+                        normalizeName(motionDTO.getInfoSlide()), motionDTO.getReference());
+                motion = motionService.addMotion(motion);
+                motionDTO.setDbId(motion.getId());
+                tournamentService.addMotionToTournament(tournament.getId(), motion);
             }
-            try {
-                for (RoundDTO roundDTO : roundsDTOs) {
-                    Round round = new Round(roundDTO.getName(), null, roundDTO.isElimination());
-                    round = roundService.addRound(round);
-                    roundDTO.setDbId(round.getId());
-                    try {
-                        for (DebateDTO debateDTO : roundDTO.getDebates()) {
-                            //get the judges for the debate
-                            List<Judge> judges = new ArrayList<>();
-                            List<String> judgeIds = List.of(debateDTO.getAdjudicatorIds().split(" "));
-                            for (String judgeId : judgeIds) {
-                                JudgeDTO judgeDTO = judgeDTOMap.get(judgeId);
-                                Judge judge = judgeService.findJudgeById(judgeDTO.getDbId());
-                                if (judge != null) {
-                                    judges.add(judge);
-                                }
-                            }
 
-                            //get the teams for the debate
-                            Team prop = teamService.findTeamById(teamDTOMap.get(debateDTO.getSides().get(0).getTeamId()).getDbId());
-                            Team opp = teamService.findTeamById(teamDTOMap.get(debateDTO.getSides().get(1).getTeamId()).getDbId());
+            // Batch-load lookup caches to avoid per-debate queries inside the rounds loop
+            Map<Long, Judge> judgeCache = judgeService
+                    .findAllJudgesByIds(judgeDTOMap.values().stream()
+                            .map(JudgeDTO::getDbId).filter(Objects::nonNull).collect(Collectors.toSet()))
+                    .stream().collect(Collectors.toMap(Judge::getId, j -> j));
 
-                            //Get the motion for the round
-                            String motionId = debateDTO.getMotionId();
-                            MotionDTO motionDTO = motionDTOs.stream().filter(m -> m.getId().equals(motionId))
-                                    .findFirst().orElse(null);
-                            Motion motion = null;
-                            if (motionDTO != null) {
-                                motion = motionService.findMotionById(motionDTO.getDbId());
-                            }
+            Map<Long, Team> teamCache = teamService
+                    .findAllTeamsByIds(teamDTOMap.values().stream()
+                            .map(TeamDTO::getDbId).filter(Objects::nonNull).collect(Collectors.toSet()))
+                    .stream().collect(Collectors.toMap(Team::getId, t -> t));
 
-                            //check how many ballots are there for each side
-                            int propBallots = debateDTO.getSides().get(0).getFinalTeamBallots().size();
-                            int oppBallots = debateDTO.getSides().get(1).getFinalTeamBallots().size();
+            Map<Long, Motion> motionCache = motionService
+                    .findAllMotionsByIds(motionDTOs.stream()
+                            .map(MotionDTO::getDbId).filter(Objects::nonNull).collect(Collectors.toSet()))
+                    .stream().collect(Collectors.toMap(Motion::getId, m -> m));
 
-                            if (propBallots != oppBallots) {
-                                System.out.println("Ballot count mismatch");
-                                continue;
-                            }
-                            // check if elimination debate
-                            List<EliminationBallot> eliminationBallots = new ArrayList<>();
-                            if (roundDTO.isElimination()) {
-                                try {
-                                    Team tempTeam1 = teamService.findTeamById(
-                                            teamDTOMap.get(debateDTO.getSides().get(0).getTeamId()).getDbId());
-                                    Team tempTeam2 = teamService.findTeamById(
-                                            teamDTOMap.get(debateDTO.getSides().get(1).getTeamId()).getDbId());
-                                    for (SideDTO sideDTO : debateDTO.getSides()) {
-                                        Team currentTeam = teamService.findTeamById(
-                                                teamDTOMap.get(sideDTO.getTeamId()).getDbId());
-                                        for (FinalTeamBallotDTO finalTeamBallotDTO : sideDTO.getFinalTeamBallots()) {
-                                            String judgeId = finalTeamBallotDTO.getAdjudicatorIds().get(0);
-                                            Judge judge = judgeService.findJudgeById(
-                                                    judgeDTOMap.get(judgeId).getDbId());
-                                            if (finalTeamBallotDTO.getRank() == 1 && currentTeam.getId()
-                                                    .equals(tempTeam1.getId())) {
-                                                eliminationBallots.add(
-                                                        new EliminationBallot(judge, tempTeam1, tempTeam2));
-                                            } else if (finalTeamBallotDTO.getRank() == 1 && currentTeam.getId()
-                                                    .equals(tempTeam2.getId())) {
-                                                eliminationBallots.add(
-                                                        new EliminationBallot(judge, tempTeam2, tempTeam1));
-                                            }
-                                        }
-                                    }
-                                    for (EliminationBallot eliminationBallot : eliminationBallots) {
-                                        eliminationBallotService.addEliminationBallot(eliminationBallot);
-                                    }
-                                } catch (Exception e) {
-                                    log.error("Error in adding elimination ballot : " + e.getMessage(), e);
-                                }
+            Map<Long, Debater> debaterCache = debaterService
+                    .findAllDebatersByIds(debaterDTOMap.values().stream()
+                            .map(DebaterDTO::getDbId).filter(Objects::nonNull).collect(Collectors.toSet()))
+                    .stream().collect(Collectors.toMap(Debater::getId, d -> d));
 
-                            }
-                            //check if ballots are ignored
-                            List<String> ignoredBallotAdjIds = new ArrayList<>();
-                            List<FinalTeamBallotDTO> adjBallots = debateDTO.getSides().get(0).getFinalTeamBallots();
-                            for (FinalTeamBallotDTO adjBallot : adjBallots) {
-                                if (adjBallot.isIgnored()) {
-                                    ignoredBallotAdjIds.addAll(adjBallot.getAdjudicatorIds());
-                                }
-                            }
+            for (RoundDTO roundDTO : roundsDTOs) {
+                Round round = new Round(roundDTO.getName(), null, roundDTO.isElimination());
+                round = roundService.addRound(round);
+                roundDTO.setDbId(round.getId());
 
-                            try {
-                                List<Ballot> ballots = new ArrayList<>();
-                                if (!roundDTO.isElimination()) {
-                                    for (SideDTO sideDTO : debateDTO.getSides()) {
-                                        for (SpeechDTO speechDTO : sideDTO.getSpeeches()) {
-                                            for (IndividualSpeechBallotDTO individualSpeechBallotDTO : speechDTO.getIndividualSpeechBallots()) {
-                                                String judgeId = individualSpeechBallotDTO.getAdjudicatorId();
-                                                String debaterId = speechDTO.getSpeakerId();
-                                                double score = individualSpeechBallotDTO.getScore();
-
-                                                if (ignoredBallotAdjIds.contains(judgeId)) {
-                                                    continue;
-                                                }
-                                                //judgeId may contain multiple adjudicators, take the first one (chair)
-                                                judgeId = judgeId.split(" ")[0];
-                                                Judge judge = judgeService.findJudgeById(judgeDTOMap.get(judgeId).getDbId());
-                                                Debater debater = debaterService.findDebaterById(debaterDTOMap.get(debaterId).getDbId());
-                                                if (judge != null && debater != null) {
-                                                    Ballot ballot = new Ballot(judge, debater, (float) score, speechDTO.getSpeakerPosition());
-                                                    ballotService.addBallot(ballot);
-                                                    ballots.add(ballot);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                Debate debate;
-                                if (roundDTO.isElimination()) {
-                                    debate = new Debate(prop, opp, null, null, motion);
-                                    debate.setEliminationBallots(eliminationBallots);
-                                    //                                    Check winner
-                                    if (eliminationBallots.size() == 1) {
-                                        Team winner = eliminationBallots.get(0).getWinner();
-                                        debate.setWinner(winner);
-                                    } else {
-                                        List<Team> propVotes = new ArrayList<>();
-                                        List<Team> oppVotes = new ArrayList<>();
-                                        for (EliminationBallot eliminationBallot : eliminationBallots) {
-                                            if (eliminationBallot.getWinner().equals(prop)) {
-                                                propVotes.add(prop);
-                                            } else {
-                                                oppVotes.add(opp);
-                                            }
-                                        }
-                                        if (propVotes.size() > oppVotes.size()) {
-                                            debate.setWinner(prop);
-                                        } else {
-                                            debate.setWinner(opp);
-                                        }
-                                    }
-
-                                } else {
-                                    debate = new Debate(prop, opp, null, ballots, motion);
-                                    String side0TeamId = debateDTO.getSides().get(0).getTeamId();
-                                    String side1TeamId = debateDTO.getSides().get(1).getTeamId();
-                                    Team side0Team = teamService.findTeamById(teamDTOMap.get(side0TeamId).getDbId());
-                                    Team side1Team = teamService.findTeamById(teamDTOMap.get(side1TeamId).getDbId());
-                                    List<Integer> side0Votes = new ArrayList<>();
-                                    List<Integer> side1Votes = new ArrayList<>();
-                                    for (FinalTeamBallotDTO finalTeamBallotDTO : debateDTO.getSides().get(0)
-                                            .getFinalTeamBallots()) {
-                                        if (finalTeamBallotDTO.getRank() == 1) {
-                                            side0Votes.add(1);
-                                        } else {
-                                            side0Votes.add(0);
-                                        }
-                                    }
-                                    for (FinalTeamBallotDTO finalTeamBallotDTO : debateDTO.getSides().get(1)
-                                            .getFinalTeamBallots()) {
-                                        if (finalTeamBallotDTO.getRank() == 1) {
-                                            side1Votes.add(1);
-                                        } else {
-                                            side1Votes.add(0);
-                                        }
-                                    }
-                                    int side0Sum = side0Votes.stream().mapToInt(Integer::intValue).sum();
-                                    int side1Sum = side1Votes.stream().mapToInt(Integer::intValue).sum();
-                                    if (side0Sum > side1Sum) {
-                                        debate.setWinner(side0Team);
-                                    } else if (side0Sum < side1Sum) {
-                                        debate.setWinner(side1Team);
-                                    }
-
-                                }
-                                debate = debateService.addDebate(debate);
-                                roundService.addDebateToRound(round.getId(), debate);
-                                //TODO check here
-                            } catch (Exception e) {
-                                log.error("Error in adding debate to round : " + e.getMessage(), e);
-                            }
-
-                        }
-                    } catch (Exception e) {
-                        log.error("Error in adding debate to round : " + e.getMessage(), e);
-                    }
-                    tournamentService.addRoundToTournament(tournament.getId(), round);
-                }
-            } catch (Exception e) {
-                log.error("Error in adding round : " + e.getMessage(), e);
-            }
-            // Feedback processing disabled - not supported in test environments with H2 database
-            // Uncomment when using PostgreSQL with full feedback support
-            /*
-            try {
-                for (JudgeDTO judgeDTO : judgeDTOs) {
-                    Judge judge = judgeService.findJudgeById(judgeDTO.getDbId());
-                    List<FeedbackDTO> feedbackDTOs = judgeDTO.getFeedback();
-                    for (FeedbackDTO feedbackDTO : feedbackDTOs) {
-                        try {
-                            Team sourceTeam = null;
-                            Judge sourceJudge = null;
-                            if (feedbackDTO.getSourceJudgeId() == null) {
-                                // Feedback from a team
-                                String sourceTeamId = feedbackDTO.getSourceTeamId();
-                                if (sourceTeamId != null && teamDTOMap.containsKey(sourceTeamId)) {
-                                    TeamDTO teamDTO = teamDTOMap.get(sourceTeamId);
-                                    if (teamDTO != null && teamDTO.getDbId() != null) {
-                                        sourceTeam = teamService.findTeamById(teamDTO.getDbId());
-                                    }
-                                } else {
-                                    log.warn("Team ID not found in map for feedback: " + sourceTeamId);
-                                }
-                            } else {
-                                // Feedback from a judge
-                                String sourceJudgeIdStr = feedbackDTO.getSourceJudgeId();
-                                if (sourceJudgeIdStr != null && judgeDTOMap.containsKey(sourceJudgeIdStr)) {
-                                    JudgeDTO sourceJudgeDTO = judgeDTOMap.get(sourceJudgeIdStr);
-                                    if (sourceJudgeDTO != null && sourceJudgeDTO.getDbId() != null) {
-                                        sourceJudge = judgeService.findJudgeById(sourceJudgeDTO.getDbId());
-                                    }
-                                } else {
-                                    log.warn("Judge ID not found in map for feedback: " + sourceJudgeIdStr);
-                                }
-                            }
-                            Float clashEvaluation = feedbackDTO.getClashEvaluation();
-                            Float clashOrganization = feedbackDTO.getClashOrganization();
-                            Float trackingArguments = feedbackDTO.getTrackingArguments();
-                            String comments = feedbackDTO.getComments();
-                            Float overallRating = feedbackDTO.getOverallRating();
-                            String agree = feedbackDTO.getAgree();
-                            Feedback feedback = new Feedback(judge, overallRating, clashEvaluation, clashOrganization,
-                                    trackingArguments, agree, comments);
-                            if (sourceTeam != null) {
-                                feedback.setSourceTeam(sourceTeam);
-                            } else if (sourceJudge != null) {
-                                feedback.setSourceJudge(sourceJudge);
-                            }
-                            //                            feedbackService.addFeedback(feedback);
-                        } catch (Exception e) {
-                            log.error("Error in adding feedback to judge : " + e.getMessage(), e);
+                for (DebateDTO debateDTO : roundDTO.getDebates()) {
+                    List<Judge> judges = new ArrayList<>();
+                    List<String> judgeIds = List.of(debateDTO.getAdjudicatorIds().split(" "));
+                    for (String judgeId : judgeIds) {
+                        JudgeDTO judgeDTO = judgeDTOMap.get(judgeId);
+                        Judge judge = judgeCache.get(judgeDTO.getDbId());
+                        if (judge != null) {
+                            judges.add(judge);
                         }
                     }
+
+                    Team prop = teamCache.get(teamDTOMap.get(debateDTO.getSides().get(0).getTeamId()).getDbId());
+                    Team opp = teamCache.get(teamDTOMap.get(debateDTO.getSides().get(1).getTeamId()).getDbId());
+
+                    if (prop == null || opp == null) {
+                        log.error("Skipping debate in round '{}': could not resolve proposition ({}) or opposition ({}) team",
+                                roundDTO.getName(),
+                                debateDTO.getSides().get(0).getTeamId(),
+                                debateDTO.getSides().get(1).getTeamId());
+                        continue;
+                    }
+
+                    String motionId = debateDTO.getMotionId();
+                    MotionDTO motionDTO = motionDTOs.stream().filter(m -> m.getId().equals(motionId))
+                            .findFirst().orElse(null);
+                    Motion motion = motionDTO != null ? motionCache.get(motionDTO.getDbId()) : null;
+
+                    int propBallots = debateDTO.getSides().get(0).getFinalTeamBallots().size();
+                    int oppBallots = debateDTO.getSides().get(1).getFinalTeamBallots().size();
+
+                    if (propBallots != oppBallots) {
+                        log.error("Skipping debate in round '{}': ballot count mismatch (prop={}, opp={})",
+                                roundDTO.getName(), propBallots, oppBallots);
+                        continue;
+                    }
+
+                    List<EliminationBallot> eliminationBallots = new ArrayList<>();
+                    if (roundDTO.isElimination()) {
+                        Team tempTeam1 = teamCache.get(teamDTOMap.get(debateDTO.getSides().get(0).getTeamId()).getDbId());
+                        Team tempTeam2 = teamCache.get(teamDTOMap.get(debateDTO.getSides().get(1).getTeamId()).getDbId());
+                        if (tempTeam1 == null || tempTeam2 == null) {
+                            log.error("Skipping elimination ballot in round '{}': could not resolve teams", roundDTO.getName());
+                        } else {
+                            for (SideDTO sideDTO : debateDTO.getSides()) {
+                                Team currentTeam = teamCache.get(teamDTOMap.get(sideDTO.getTeamId()).getDbId());
+                                for (FinalTeamBallotDTO finalTeamBallotDTO : sideDTO.getFinalTeamBallots()) {
+                                    String judgeId = finalTeamBallotDTO.getAdjudicatorIds().get(0);
+                                    Judge judge = judgeCache.get(judgeDTOMap.get(judgeId).getDbId());
+                                    if (finalTeamBallotDTO.getRank() == 1 && currentTeam.getId().equals(tempTeam1.getId())) {
+                                        eliminationBallots.add(new EliminationBallot(judge, tempTeam1, tempTeam2));
+                                    } else if (finalTeamBallotDTO.getRank() == 1 && currentTeam.getId().equals(tempTeam2.getId())) {
+                                        eliminationBallots.add(new EliminationBallot(judge, tempTeam2, tempTeam1));
+                                    }
+                                }
+                            }
+                            for (EliminationBallot eliminationBallot : eliminationBallots) {
+                                eliminationBallotService.addEliminationBallot(eliminationBallot);
+                            }
+                        }
+                    }
+
+                    List<String> ignoredBallotAdjIds = new ArrayList<>();
+                    List<FinalTeamBallotDTO> adjBallots = debateDTO.getSides().get(0).getFinalTeamBallots();
+                    for (FinalTeamBallotDTO adjBallot : adjBallots) {
+                        if (adjBallot.isIgnored()) {
+                            ignoredBallotAdjIds.addAll(adjBallot.getAdjudicatorIds());
+                        }
+                    }
+
+                    List<Ballot> ballots = new ArrayList<>();
+                    if (!roundDTO.isElimination()) {
+                        for (SideDTO sideDTO : debateDTO.getSides()) {
+                            for (SpeechDTO speechDTO : sideDTO.getSpeeches()) {
+                                for (IndividualSpeechBallotDTO individualSpeechBallotDTO : speechDTO.getIndividualSpeechBallots()) {
+                                    String judgeId = individualSpeechBallotDTO.getAdjudicatorId();
+                                    String debaterId = speechDTO.getSpeakerId();
+                                    double score = individualSpeechBallotDTO.getScore();
+
+                                    if (ignoredBallotAdjIds.contains(judgeId)) {
+                                        continue;
+                                    }
+                                    //judgeId may contain multiple adjudicators, take the first one (chair)
+                                    judgeId = judgeId.split(" ")[0];
+                                    Judge judge = judgeCache.get(judgeDTOMap.get(judgeId).getDbId());
+                                    Debater debater = debaterCache.get(debaterDTOMap.get(debaterId).getDbId());
+                                    if (judge != null && debater != null) {
+                                        Ballot ballot = new Ballot(judge, debater, (float) score, speechDTO.getSpeakerPosition());
+                                        ballotService.addBallot(ballot);
+                                        ballots.add(ballot);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Debate debate;
+                    if (roundDTO.isElimination()) {
+                        debate = new Debate(prop, opp, null, null, motion);
+                        debate.setEliminationBallots(eliminationBallots);
+                        if (eliminationBallots.size() == 1) {
+                            debate.setWinner(eliminationBallots.get(0).getWinner());
+                        } else {
+                            long propWins = eliminationBallots.stream()
+                                    .filter(b -> b.getWinner().equals(prop)).count();
+                            long oppWins = eliminationBallots.size() - propWins;
+                            debate.setWinner(propWins > oppWins ? prop : opp);
+                        }
+                    } else {
+                        debate = new Debate(prop, opp, null, ballots, motion);
+                        String side0TeamId = debateDTO.getSides().get(0).getTeamId();
+                        String side1TeamId = debateDTO.getSides().get(1).getTeamId();
+                        Team side0Team = teamCache.get(teamDTOMap.get(side0TeamId).getDbId());
+                        Team side1Team = teamCache.get(teamDTOMap.get(side1TeamId).getDbId());
+                        long side0Wins = debateDTO.getSides().get(0).getFinalTeamBallots().stream()
+                                .filter(b -> b.getRank() == 1).count();
+                        long side1Wins = debateDTO.getSides().get(1).getFinalTeamBallots().stream()
+                                .filter(b -> b.getRank() == 1).count();
+                        if (side0Wins > side1Wins) {
+                            debate.setWinner(side0Team);
+                        } else if (side0Wins < side1Wins) {
+                            debate.setWinner(side1Team);
+                        }
+                    }
+                    debate = debateService.addDebate(debate);
+                    roundService.addDebateToRound(round.getId(), debate);
                 }
-            } catch (Exception e) {
-                log.error("Error in adding feedback : " + e.getMessage(), e);
+                tournamentService.addRoundToTournament(tournament.getId(), round);
             }
-            */
+
             log.debug("Feedback processing skipped (disabled for test environment compatibility)");
 
-            // Create and return comprehensive tournament data DTO
-            TournamentDataDTO tournamentDataDTO = new TournamentDataDTO(tournamentDTO,
+            return new TournamentDataDTO(tournamentDTO,
                     new ArrayList<>(debaterDTOMap.values()), teamDTOs, judgeDTOs, institutionDTOs, motionDTOs,
                     breakCategoryDTOs, roundsDTOs, debaterDTOMap, teamDTOMap, judgeDTOMap);
-
-            return tournamentDataDTO;
         } catch (Exception e) {
             log.error("Error in building tournament : " + e.getMessage(), e);
-            return null;
+            throw new RuntimeException("Tournament build failed: " + e.getMessage(), e);
         }
     }
 
@@ -543,10 +429,11 @@ public class TournamentBuilder {
     public String getTournamentSummary(@RequestParam String fileName,
             @RequestParam(required = false) Integer year) {
         int selectedYear = year != null ? year : DEFAULT_SUMMARY_YEAR;
-        TournamentDataDTO tournamentData = buildMyTournament(buildTournamentFilePath(fileName, selectedYear));
-
-        if (tournamentData == null) {
-            return "Failed to build tournament data";
+        TournamentDataDTO tournamentData;
+        try {
+            tournamentData = buildMyTournament(buildTournamentFilePath(fileName, selectedYear));
+        } catch (Exception e) {
+            return "Failed to build tournament data: " + e.getMessage();
         }
 
         StringBuilder summary = new StringBuilder();

--- a/src/main/java/com/dineth/debateTracker/TournamentImportService.java
+++ b/src/main/java/com/dineth/debateTracker/TournamentImportService.java
@@ -1,0 +1,388 @@
+package com.dineth.debateTracker;
+
+import com.dineth.debateTracker.ballot.Ballot;
+import com.dineth.debateTracker.ballot.BallotService;
+import com.dineth.debateTracker.breakcategory.BreakCategory;
+import com.dineth.debateTracker.breakcategory.BreakCategoryService;
+import com.dineth.debateTracker.debate.Debate;
+import com.dineth.debateTracker.debate.DebateService;
+import com.dineth.debateTracker.debater.Debater;
+import com.dineth.debateTracker.debater.DebaterService;
+import com.dineth.debateTracker.dtos.TournamentDataDTO;
+import com.dineth.debateTracker.dtos.xmlparsing.*;
+import com.dineth.debateTracker.eliminationballot.EliminationBallot;
+import com.dineth.debateTracker.eliminationballot.EliminationBallotService;
+import com.dineth.debateTracker.institution.Institution;
+import com.dineth.debateTracker.institution.InstitutionService;
+import com.dineth.debateTracker.judge.Judge;
+import com.dineth.debateTracker.judge.JudgeService;
+import com.dineth.debateTracker.motion.Motion;
+import com.dineth.debateTracker.motion.MotionService;
+import com.dineth.debateTracker.round.Round;
+import com.dineth.debateTracker.round.RoundService;
+import com.dineth.debateTracker.team.Team;
+import com.dineth.debateTracker.team.TeamService;
+import com.dineth.debateTracker.tournament.Tournament;
+import com.dineth.debateTracker.tournament.TournamentService;
+import com.dineth.debateTracker.utils.ParseTabbycatXML;
+import com.dineth.debateTracker.utils.StringUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.dineth.debateTracker.utils.StringUtil.normalizeName;
+
+/**
+ * Imports a Tabbycat XML export into the database. Parses the XML into DTOs, persists every
+ * entity (institutions, judges, teams/debaters, break categories, motions, rounds, debates,
+ * ballots), and returns a summary {@link TournamentDataDTO}.
+ *
+ * <p>The whole import runs in a single transaction: any failure rolls back the entire tournament
+ * so partial imports never reach the database.
+ */
+@Service
+@Slf4j
+public class TournamentImportService {
+
+    private final JudgeService judgeService;
+    private final TeamService teamService;
+    private final DebaterService debaterService;
+    private final DebateService debateService;
+    private final InstitutionService institutionService;
+    private final MotionService motionService;
+    private final TournamentService tournamentService;
+    private final BreakCategoryService breakCategoryService;
+    private final BallotService ballotService;
+    private final RoundService roundService;
+    private final EliminationBallotService eliminationBallotService;
+
+    @Autowired
+    public TournamentImportService(JudgeService judgeService, TeamService teamService, DebaterService debaterService,
+            DebateService debateService, InstitutionService institutionService, MotionService motionService,
+            TournamentService tournamentService, BreakCategoryService breakCategoryService, BallotService ballotService,
+            RoundService roundService, EliminationBallotService eliminationBallotService) {
+        this.judgeService = judgeService;
+        this.teamService = teamService;
+        this.debaterService = debaterService;
+        this.debateService = debateService;
+        this.institutionService = institutionService;
+        this.motionService = motionService;
+        this.tournamentService = tournamentService;
+        this.breakCategoryService = breakCategoryService;
+        this.ballotService = ballotService;
+        this.roundService = roundService;
+        this.eliminationBallotService = eliminationBallotService;
+    }
+
+    /**
+     * In-memory caches of persisted entities keyed by their database id, built once before the
+     * rounds loop so debate processing never queries the database per debate.
+     */
+    private record LookupCaches(Map<Long, Judge> judges, Map<Long, Team> teams,
+                                Map<Long, Motion> motions, Map<Long, Debater> debaters) {
+    }
+
+    @Transactional
+    public TournamentDataDTO importTournament(String filePath) {
+        try {
+            ParseTabbycatXML parser = new ParseTabbycatXML(filePath);
+            parser.parseXML();
+
+            TournamentDTO tournamentDTO = parser.getTournamentDTO();
+            List<TeamDTO> teamDTOs = parser.getTeamDTOs();
+            List<JudgeDTO> judgeDTOs = parser.getJudgeDTOs();
+            List<InstitutionDTO> institutionDTOs = parser.getInstitutionDTOs();
+            List<MotionDTO> motionDTOs = parser.getMotionDTOs();
+            List<RoundDTO> roundDTOs = parser.getRoundsDTO();
+            List<BreakCategoryDTO> breakCategoryDTOs = parser.getBreakCategoryDTOs();
+
+            // XML-id -> DTO maps, populated as entities are persisted and used to resolve references
+            Map<String, DebaterDTO> debaterDTOMap = new HashMap<>();
+            Map<String, TeamDTO> teamDTOMap = new HashMap<>();
+            Map<String, JudgeDTO> judgeDTOMap = new HashMap<>();
+
+            saveInstitutions(institutionDTOs);
+            saveJudges(judgeDTOs, judgeDTOMap);
+            saveTeams(teamDTOs, institutionDTOs, debaterDTOMap, teamDTOMap);
+
+            Tournament tournament = tournamentService.addTournament(
+                    new Tournament(tournamentDTO.getFullName(), tournamentDTO.getShortName()));
+            saveBreakCategories(breakCategoryDTOs, tournament);
+            saveMotions(motionDTOs, tournament);
+
+            LookupCaches caches = buildLookupCaches(judgeDTOMap, teamDTOMap, motionDTOs, debaterDTOMap);
+            Map<String, MotionDTO> motionDTOMap = motionDTOs.stream()
+                    .collect(Collectors.toMap(MotionDTO::getId, m -> m, (a, b) -> a));
+
+            for (RoundDTO roundDTO : roundDTOs) {
+                processRound(roundDTO, tournament, judgeDTOMap, teamDTOMap, motionDTOMap, debaterDTOMap, caches);
+            }
+
+            return new TournamentDataDTO(tournamentDTO, new ArrayList<>(debaterDTOMap.values()),
+                    teamDTOs, judgeDTOs, institutionDTOs, motionDTOs, breakCategoryDTOs, roundDTOs);
+        } catch (Exception e) {
+            log.error("Error in building tournament : " + e.getMessage(), e);
+            throw new RuntimeException("Tournament build failed: " + e.getMessage(), e);
+        }
+    }
+
+    private void saveInstitutions(List<InstitutionDTO> institutionDTOs) {
+        for (InstitutionDTO institutionDTO : institutionDTOs) {
+            Institution existing = institutionService.findInstitutionByName(institutionDTO.name.strip());
+            if (existing == null) {
+                log.debug("Adding institution : " + institutionDTO.name);
+                Institution institution = institutionService.addInstitution(
+                        new Institution(institutionDTO.name.strip(), institutionDTO.reference));
+                institutionDTO.dbId = institution.getId();
+            } else {
+                log.debug("Institution already exists : " + institutionDTO.name);
+                institutionDTO.dbId = existing.getId();
+            }
+        }
+    }
+
+    private void saveJudges(List<JudgeDTO> judgeDTOs, Map<String, JudgeDTO> judgeDTOMap) {
+        for (JudgeDTO judgeDTO : judgeDTOs) {
+            ImmutablePair<String, String> names = StringUtil.splitName(judgeDTO.getName());
+            Judge judge = new Judge(judgeDTO.getScore(), names.getLeft(), names.getRight());
+            Judge existingJudge = judgeService.checkJudgeExists(judge);
+            judge = existingJudge != null ? existingJudge : judgeService.addJudge(judge);
+            judgeDTO.setDbId(judge.getId());
+            judgeDTOMap.put(judgeDTO.getId(), judgeDTO);
+        }
+    }
+
+    private void saveTeams(List<TeamDTO> teamDTOs, List<InstitutionDTO> institutionDTOs,
+            Map<String, DebaterDTO> debaterDTOMap, Map<String, TeamDTO> teamDTOMap) {
+        for (TeamDTO teamDTO : teamDTOs) {
+            List<DebaterDTO> debaterDTOs = teamDTO.getDebaters();
+            List<Debater> debaters = saveDebaters(debaterDTOs, debaterDTOMap);
+            Team team = teamService.addTeam(new Team(teamDTO.getName(), teamDTO.getCode(), debaters));
+            teamDTO.setDbId(team.getId());
+            teamDTOMap.put(teamDTO.getId(), teamDTO);
+            linkTeamToInstitution(teamDTO, debaterDTOs, institutionDTOs, team);
+        }
+    }
+
+    private List<Debater> saveDebaters(List<DebaterDTO> debaterDTOs, Map<String, DebaterDTO> debaterDTOMap) {
+        List<Debater> debaters = new ArrayList<>();
+        for (DebaterDTO debaterDTO : debaterDTOs) {
+            ImmutablePair<String, String> names = StringUtil.splitName(debaterDTO.getName());
+            Debater debater = new Debater(StringUtil.capitalizeName(names.getLeft()),
+                    StringUtil.capitalizeName(names.getRight()));
+            Debater existing = debaterService.checkIfDebaterExists(debater);
+            debater = existing != null ? existing : debaterService.addDebater(debater);
+            debaterDTO.setDbId(debater.getId());
+            debaterDTOMap.put(debaterDTO.getId(), debaterDTO);
+            debaters.add(debater);
+        }
+        return debaters;
+    }
+
+    private void linkTeamToInstitution(TeamDTO teamDTO, List<DebaterDTO> debaterDTOs,
+            List<InstitutionDTO> institutionDTOs, Team team) {
+        if (debaterDTOs.isEmpty()) {
+            log.error("No debaters found for team : " + teamDTO.getName());
+            return;
+        }
+        String institutionId = debaterDTOs.get(0).getInstitutionId();
+        if (institutionId == null || institutionId.isEmpty()) {
+            log.debug("No institution ID found for team : " + teamDTO.getName());
+            return;
+        }
+        Institution institution = institutionDTOs.stream()
+                .filter(inst -> inst.getId().equals(institutionId)).findFirst()
+                .map(inst -> institutionService.findInstitutionById(inst.getDbId())).orElse(null);
+        if (institution != null) {
+            institutionService.addTeamToInstitution(institution.getId(), team);
+        } else {
+            log.debug("Institution not found for team : " + teamDTO.getName());
+        }
+    }
+
+    private void saveBreakCategories(List<BreakCategoryDTO> breakCategoryDTOs, Tournament tournament) {
+        for (BreakCategoryDTO breakCategoryDTO : breakCategoryDTOs) {
+            BreakCategory breakCategory = breakCategoryService.addBreakCategory(
+                    new BreakCategory(breakCategoryDTO.getName()));
+            breakCategoryDTO.setDbId(breakCategory.getId());
+            tournamentService.addBreakCategoryToTournament(tournament.getId(), breakCategory);
+        }
+    }
+
+    private void saveMotions(List<MotionDTO> motionDTOs, Tournament tournament) {
+        for (MotionDTO motionDTO : motionDTOs) {
+            Motion motion = motionService.addMotion(new Motion(normalizeName(motionDTO.getMotion()),
+                    normalizeName(motionDTO.getInfoSlide()), motionDTO.getReference()));
+            motionDTO.setDbId(motion.getId());
+            tournamentService.addMotionToTournament(tournament.getId(), motion);
+        }
+    }
+
+    private LookupCaches buildLookupCaches(Map<String, JudgeDTO> judgeDTOMap, Map<String, TeamDTO> teamDTOMap,
+            List<MotionDTO> motionDTOs, Map<String, DebaterDTO> debaterDTOMap) {
+        Map<Long, Judge> judges = judgeService.findAllJudgesByIds(dbIds(judgeDTOMap.values(), JudgeDTO::getDbId))
+                .stream().collect(Collectors.toMap(Judge::getId, j -> j));
+        Map<Long, Team> teams = teamService.findAllTeamsByIds(dbIds(teamDTOMap.values(), TeamDTO::getDbId))
+                .stream().collect(Collectors.toMap(Team::getId, t -> t));
+        Map<Long, Motion> motions = motionService.findAllMotionsByIds(dbIds(motionDTOs, MotionDTO::getDbId))
+                .stream().collect(Collectors.toMap(Motion::getId, m -> m));
+        Map<Long, Debater> debaters = debaterService.findAllDebatersByIds(dbIds(debaterDTOMap.values(), DebaterDTO::getDbId))
+                .stream().collect(Collectors.toMap(Debater::getId, d -> d));
+        return new LookupCaches(judges, teams, motions, debaters);
+    }
+
+    private static <T> Set<Long> dbIds(Collection<T> dtos, Function<T, Long> idGetter) {
+        return dtos.stream().map(idGetter).filter(Objects::nonNull).collect(Collectors.toSet());
+    }
+
+    private void processRound(RoundDTO roundDTO, Tournament tournament,
+            Map<String, JudgeDTO> judgeDTOMap, Map<String, TeamDTO> teamDTOMap,
+            Map<String, MotionDTO> motionDTOMap, Map<String, DebaterDTO> debaterDTOMap, LookupCaches caches)
+            throws Exception {
+        Round round = roundService.addRound(new Round(roundDTO.getName(), null, roundDTO.isElimination()));
+        roundDTO.setDbId(round.getId());
+
+        for (DebateDTO debateDTO : roundDTO.getDebates()) {
+            Debate debate = buildDebate(debateDTO, roundDTO, judgeDTOMap, teamDTOMap, motionDTOMap, debaterDTOMap, caches);
+            if (debate == null) {
+                continue;
+            }
+            debate = debateService.addDebate(debate);
+            roundService.addDebateToRound(round.getId(), debate);
+        }
+        tournamentService.addRoundToTournament(tournament.getId(), round);
+    }
+
+    /**
+     * Build a single debate (persisting its ballots as a side effect), or return {@code null} if the
+     * debate must be skipped (unresolved teams or a ballot-count mismatch).
+     */
+    private Debate buildDebate(DebateDTO debateDTO, RoundDTO roundDTO,
+            Map<String, JudgeDTO> judgeDTOMap, Map<String, TeamDTO> teamDTOMap,
+            Map<String, MotionDTO> motionDTOMap, Map<String, DebaterDTO> debaterDTOMap, LookupCaches caches) {
+        Team prop = caches.teams().get(teamDTOMap.get(debateDTO.getSides().get(0).getTeamId()).getDbId());
+        Team opp = caches.teams().get(teamDTOMap.get(debateDTO.getSides().get(1).getTeamId()).getDbId());
+        if (prop == null || opp == null) {
+            log.error("Skipping debate in round '{}': could not resolve proposition ({}) or opposition ({}) team",
+                    roundDTO.getName(),
+                    debateDTO.getSides().get(0).getTeamId(),
+                    debateDTO.getSides().get(1).getTeamId());
+            return null;
+        }
+
+        MotionDTO motionDTO = motionDTOMap.get(debateDTO.getMotionId());
+        Motion motion = motionDTO != null ? caches.motions().get(motionDTO.getDbId()) : null;
+
+        int propBallots = debateDTO.getSides().get(0).getFinalTeamBallots().size();
+        int oppBallots = debateDTO.getSides().get(1).getFinalTeamBallots().size();
+        if (propBallots != oppBallots) {
+            log.error("Skipping debate in round '{}': ballot count mismatch (prop={}, opp={})",
+                    roundDTO.getName(), propBallots, oppBallots);
+            return null;
+        }
+
+        if (roundDTO.isElimination()) {
+            List<EliminationBallot> eliminationBallots =
+                    buildEliminationBallots(debateDTO, teamDTOMap, judgeDTOMap, caches, prop, opp);
+            Debate debate = new Debate(prop, opp, null, null, motion);
+            debate.setEliminationBallots(eliminationBallots);
+            debate.setWinner(determineEliminationWinner(eliminationBallots, prop, opp));
+            return debate;
+        }
+
+        List<Ballot> ballots = buildBallots(debateDTO, judgeDTOMap, debaterDTOMap, caches);
+        Debate debate = new Debate(prop, opp, null, ballots, motion);
+        debate.setWinner(determinePrelimWinner(debateDTO, prop, opp));
+        return debate;
+    }
+
+    private List<EliminationBallot> buildEliminationBallots(DebateDTO debateDTO,
+            Map<String, TeamDTO> teamDTOMap, Map<String, JudgeDTO> judgeDTOMap, LookupCaches caches,
+            Team prop, Team opp) {
+        List<EliminationBallot> eliminationBallots = new ArrayList<>();
+        for (SideDTO sideDTO : debateDTO.getSides()) {
+            Team currentTeam = caches.teams().get(teamDTOMap.get(sideDTO.getTeamId()).getDbId());
+            for (FinalTeamBallotDTO finalTeamBallotDTO : sideDTO.getFinalTeamBallots()) {
+                String judgeId = finalTeamBallotDTO.getAdjudicatorIds().get(0);
+                Judge judge = caches.judges().get(judgeDTOMap.get(judgeId).getDbId());
+                if (finalTeamBallotDTO.getRank() == 1 && currentTeam.getId().equals(prop.getId())) {
+                    eliminationBallots.add(new EliminationBallot(judge, prop, opp));
+                } else if (finalTeamBallotDTO.getRank() == 1 && currentTeam.getId().equals(opp.getId())) {
+                    eliminationBallots.add(new EliminationBallot(judge, opp, prop));
+                }
+            }
+        }
+        for (EliminationBallot eliminationBallot : eliminationBallots) {
+            eliminationBallotService.addEliminationBallot(eliminationBallot);
+        }
+        return eliminationBallots;
+    }
+
+    private List<Ballot> buildBallots(DebateDTO debateDTO, Map<String, JudgeDTO> judgeDTOMap,
+            Map<String, DebaterDTO> debaterDTOMap, LookupCaches caches) {
+        List<String> ignoredBallotAdjIds = new ArrayList<>();
+        for (FinalTeamBallotDTO adjBallot : debateDTO.getSides().get(0).getFinalTeamBallots()) {
+            if (adjBallot.isIgnored()) {
+                ignoredBallotAdjIds.addAll(adjBallot.getAdjudicatorIds());
+            }
+        }
+
+        List<Ballot> ballots = new ArrayList<>();
+        for (SideDTO sideDTO : debateDTO.getSides()) {
+            for (SpeechDTO speechDTO : sideDTO.getSpeeches()) {
+                for (IndividualSpeechBallotDTO speechBallot : speechDTO.getIndividualSpeechBallots()) {
+                    String judgeId = speechBallot.getAdjudicatorId();
+                    if (ignoredBallotAdjIds.contains(judgeId)) {
+                        continue;
+                    }
+                    // judgeId may contain multiple adjudicators, take the first one (chair)
+                    judgeId = judgeId.split(" ")[0];
+                    Judge judge = caches.judges().get(judgeDTOMap.get(judgeId).getDbId());
+                    Debater debater = caches.debaters().get(debaterDTOMap.get(speechDTO.getSpeakerId()).getDbId());
+                    if (judge != null && debater != null) {
+                        Ballot ballot = new Ballot(judge, debater, (float) speechBallot.getScore(),
+                                speechDTO.getSpeakerPosition());
+                        ballotService.addBallot(ballot);
+                        ballots.add(ballot);
+                    }
+                }
+            }
+        }
+        return ballots;
+    }
+
+    private Team determineEliminationWinner(List<EliminationBallot> eliminationBallots, Team prop, Team opp) {
+        if (eliminationBallots.size() == 1) {
+            return eliminationBallots.get(0).getWinner();
+        }
+        long propWins = eliminationBallots.stream().filter(b -> b.getWinner().equals(prop)).count();
+        long oppWins = eliminationBallots.size() - propWins;
+        return propWins > oppWins ? prop : opp;
+    }
+
+    private Team determinePrelimWinner(DebateDTO debateDTO, Team prop, Team opp) {
+        long propWins = debateDTO.getSides().get(0).getFinalTeamBallots().stream()
+                .filter(b -> b.getRank() == 1).count();
+        long oppWins = debateDTO.getSides().get(1).getFinalTeamBallots().stream()
+                .filter(b -> b.getRank() == 1).count();
+        if (propWins > oppWins) {
+            return prop;
+        }
+        if (propWins < oppWins) {
+            return opp;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/dineth/debateTracker/TournamentImportService.java
+++ b/src/main/java/com/dineth/debateTracker/TournamentImportService.java
@@ -140,15 +140,15 @@ public class TournamentImportService {
 
     private void saveInstitutions(List<InstitutionDTO> institutionDTOs) {
         for (InstitutionDTO institutionDTO : institutionDTOs) {
-            Institution existing = institutionService.findInstitutionByName(institutionDTO.name.strip());
+            Institution existing = institutionService.findInstitutionByName(institutionDTO.getName().strip());
             if (existing == null) {
-                log.debug("Adding institution : " + institutionDTO.name);
+                log.debug("Adding institution : " + institutionDTO.getName());
                 Institution institution = institutionService.addInstitution(
-                        new Institution(institutionDTO.name.strip(), institutionDTO.reference));
-                institutionDTO.dbId = institution.getId();
+                        new Institution(institutionDTO.getName().strip(), institutionDTO.getReference()));
+                institutionDTO.setDbId(institution.getId());
             } else {
-                log.debug("Institution already exists : " + institutionDTO.name);
-                institutionDTO.dbId = existing.getId();
+                log.debug("Institution already exists : " + institutionDTO.getName());
+                institutionDTO.setDbId(existing.getId());
             }
         }
     }

--- a/src/main/java/com/dineth/debateTracker/debater/DebaterService.java
+++ b/src/main/java/com/dineth/debateTracker/debater/DebaterService.java
@@ -51,6 +51,10 @@ public class DebaterService {
     public Debater findDebaterById(Long id) {
         return debaterRepository.findById(id).orElse(null);
     }
+
+    public List<Debater> findAllDebatersByIds(Collection<Long> ids) {
+        return debaterRepository.findAllById(ids);
+    }
     
     public List<Debater> findDebatersByInstitutionId(Long institutionId) {
         return debaterRepository.findDebatersByInstitutionId(institutionId);

--- a/src/main/java/com/dineth/debateTracker/dtos/DebaterMergeInfoDTO.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/DebaterMergeInfoDTO.java
@@ -10,11 +10,11 @@ import java.util.List;
 @NoArgsConstructor @AllArgsConstructor
 @Setter @Getter
 public class DebaterMergeInfoDTO {
-    Long id;
-    String firstName;
-    String lastName;
-    String fullName;
-    String phone;
-    Integer roundsDebated;
-    List<String> teams;
+    private Long id;
+    private String firstName;
+    private String lastName;
+    private String fullName;
+    private String phone;
+    private Integer roundsDebated;
+    private List<String> teams;
 }

--- a/src/main/java/com/dineth/debateTracker/dtos/InstitutionMergeInfoDTO.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/InstitutionMergeInfoDTO.java
@@ -10,9 +10,9 @@ import java.util.List;
 @NoArgsConstructor @AllArgsConstructor
 @Setter @Getter
 public class InstitutionMergeInfoDTO {
-    Long id;
-    String name;
-    String abbreviation;
-    String teamCount;
-    List<String> teams;
+    private Long id;
+    private String name;
+    private String abbreviation;
+    private String teamCount;
+    private List<String> teams;
 }

--- a/src/main/java/com/dineth/debateTracker/dtos/JudgeMergeInfoDTO.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/JudgeMergeInfoDTO.java
@@ -10,10 +10,10 @@ import java.util.List;
 @NoArgsConstructor @AllArgsConstructor
 @Setter @Getter
 public class JudgeMergeInfoDTO {
-    Long id;
-    String firstName;
-    String lastName;
-    Integer breaks;
-    Integer prelims;
-    List<String> tournaments;
+    private Long id;
+    private String firstName;
+    private String lastName;
+    private Integer breaks;
+    private Integer prelims;
+    private List<String> tournaments;
 }

--- a/src/main/java/com/dineth/debateTracker/dtos/SpeakerTab/SpeakerTabBallot.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/SpeakerTab/SpeakerTabBallot.java
@@ -8,11 +8,11 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class SpeakerTabBallot {
-    Long ballotId;
-    Float speakerScore;
-    Integer speakerPosition;
-    Long judgeId;
-    Long roundId;
+    private Long ballotId;
+    private Float speakerScore;
+    private Integer speakerPosition;
+    private Long judgeId;
+    private Long roundId;
 
     public SpeakerTabBallot(Long ballotId, Float speakerScore, Integer speakerPosition, Long judgeId, Long roundId) {
         this.ballotId = ballotId;

--- a/src/main/java/com/dineth/debateTracker/dtos/TournamentDataDTO.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/TournamentDataDTO.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Comprehensive DTO that contains all the tournament data after XML parsing.
@@ -30,14 +29,7 @@ public class TournamentDataDTO {
     
     // Tournament structure and results
     private List<RoundDTO> rounds;
-    
-    // Mappings for quick lookup during parsing
-    private Map<String, DebaterDTO> debaterMap;
-    private Map<String, TeamDTO> teamMap;
-    private Map<String, JudgeDTO> judgeMap;
-    private Map<String, InstitutionDTO> institutionMap;
-    private Map<String, MotionDTO> motionMap;
-    
+
     // Statistics and metadata
     private TournamentMetadata metadata;
     
@@ -63,27 +55,7 @@ public class TournamentDataDTO {
         this.metadata = new TournamentMetadata();
         calculateMetadata();
     }
-    
-    /**
-     * Constructor with maps for quick lookup
-     */
-    public TournamentDataDTO(TournamentDTO tournament,
-                           List<DebaterDTO> debaters,
-                           List<TeamDTO> teams,
-                           List<JudgeDTO> judges,
-                           List<InstitutionDTO> institutions,
-                           List<MotionDTO> motions,
-                           List<BreakCategoryDTO> breakCategories,
-                           List<RoundDTO> rounds,
-                           Map<String, DebaterDTO> debaterMap,
-                           Map<String, TeamDTO> teamMap,
-                           Map<String, JudgeDTO> judgeMap) {
-        this(tournament, debaters, teams, judges, institutions, motions, breakCategories, rounds);
-        this.debaterMap = debaterMap;
-        this.teamMap = teamMap;
-        this.judgeMap = judgeMap;
-    }
-    
+
     /**
      * Calculate tournament metadata and statistics
      */
@@ -221,13 +193,9 @@ public class TournamentDataDTO {
     }
     
     /**
-     * Get team by ID (using the team map for efficiency)
+     * Get team by ID
      */
     public TeamDTO getTeamById(String teamId) {
-        if (teamMap != null) {
-            return teamMap.get(teamId);
-        }
-        // Fallback to linear search if map is not available
         if (teams == null || teamId == null) {
             return null;
         }
@@ -236,15 +204,11 @@ public class TournamentDataDTO {
                 .findFirst()
                 .orElse(null);
     }
-    
+
     /**
-     * Get judge by ID (using the judge map for efficiency)
+     * Get judge by ID
      */
     public JudgeDTO getJudgeById(String judgeId) {
-        if (judgeMap != null) {
-            return judgeMap.get(judgeId);
-        }
-        // Fallback to linear search if map is not available
         if (judges == null || judgeId == null) {
             return null;
         }
@@ -253,15 +217,11 @@ public class TournamentDataDTO {
                 .findFirst()
                 .orElse(null);
     }
-    
+
     /**
-     * Get debater by ID (using the debater map for efficiency)
+     * Get debater by ID
      */
     public DebaterDTO getDebaterById(String debaterId) {
-        if (debaterMap != null) {
-            return debaterMap.get(debaterId);
-        }
-        // Fallback to linear search if map is not available
         if (debaters == null || debaterId == null) {
             return null;
         }

--- a/src/main/java/com/dineth/debateTracker/dtos/debaterprofiles/FurthestRoundDTO.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/debaterprofiles/FurthestRoundDTO.java
@@ -12,8 +12,8 @@ import java.util.Date;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FurthestRoundDTO {
-    public String tournamentName;
-    public String roundName;
-    public Boolean won;
-    public Date date;
+    private String tournamentName;
+    private String roundName;
+    private Boolean won;
+    private Date date;
 }

--- a/src/main/java/com/dineth/debateTracker/dtos/debaterprofiles/SpeakerPerformanceDTO.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/debaterprofiles/SpeakerPerformanceDTO.java
@@ -12,10 +12,10 @@ import java.util.Date;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SpeakerPerformanceDTO {
-    public String tournamentName;
-    public Integer prelimsDebated;
-    public Integer rank;
-    public Float average;
-    public Float standardDeviation;
-    public Date date;
+    private String tournamentName;
+    private Integer prelimsDebated;
+    private Integer rank;
+    private Float average;
+    private Float standardDeviation;
+    private Date date;
 }

--- a/src/main/java/com/dineth/debateTracker/dtos/statistics/SpeakerScorePerformanceDTO.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/statistics/SpeakerScorePerformanceDTO.java
@@ -7,12 +7,12 @@ import lombok.Setter;
 
 @Getter @Setter @AllArgsConstructor @NoArgsConstructor
 public class SpeakerScorePerformanceDTO {
-    public Long debaterId;
-    public String firstName;
-    public String lastName;
-    public Long tournamentId;
-    public String tournamentShortName;
-    public Double averageSpeakerScore;
-    public Integer SpeechesGiven;
-    public Integer rank;
+    private Long debaterId;
+    private String firstName;
+    private String lastName;
+    private Long tournamentId;
+    private String tournamentShortName;
+    private Double averageSpeakerScore;
+    private Integer speechesGiven;
+    private Integer rank;
 }

--- a/src/main/java/com/dineth/debateTracker/dtos/xmlparsing/DebaterDTO.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/xmlparsing/DebaterDTO.java
@@ -23,7 +23,7 @@ public class DebaterDTO {
 
     @Override
     public String toString() {
-        return "RoundDTO{" +
+        return "DebaterDTO{" +
                 "id='" + id + '\'' +
                 ", name='" + name + '\'' +
                 ", institutionId='" + institutionId + '\'' +

--- a/src/main/java/com/dineth/debateTracker/dtos/xmlparsing/InstitutionDTO.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/xmlparsing/InstitutionDTO.java
@@ -8,10 +8,10 @@ import lombok.Setter;
 @NoArgsConstructor
 
 public class InstitutionDTO {
-    public String id;
-    public String name;
-    public String reference;
-    public Long dbId;
+    private String id;
+    private String name;
+    private String reference;
+    private Long dbId;
 
     public InstitutionDTO(String id, String name, String reference) {
         this.id = id;

--- a/src/main/java/com/dineth/debateTracker/dtos/xmlparsing/JudgeDTO.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/xmlparsing/JudgeDTO.java
@@ -27,7 +27,7 @@ public class JudgeDTO {
     }
     @Override
     public String toString() {
-        return "DebateDTO{" +
+        return "JudgeDTO{" +
                 "id='" + id + '\'' +
                 ", name='" + name + '\'' +
                 ", score='" + score + '\'' +

--- a/src/main/java/com/dineth/debateTracker/dtos/xmlparsing/TeamDTO.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/xmlparsing/TeamDTO.java
@@ -28,7 +28,7 @@ public class TeamDTO {
 
     @Override
     public String toString() {
-        return "RoundDTO{" +
+        return "TeamDTO{" +
                 "id='" + id + '\'' +
                 ", name='" + name + '\'' +
                 ", code='" + code + '\'' +

--- a/src/main/java/com/dineth/debateTracker/judge/JudgeService.java
+++ b/src/main/java/com/dineth/debateTracker/judge/JudgeService.java
@@ -51,6 +51,10 @@ public class JudgeService {
     public Judge checkJudgeExists(Judge judge) {
         return judgeRepository.findByFnameAndLname(judge.getFname(), judge.getLname());
     }
+
+    public List<Judge> findAllJudgesByIds(Collection<Long> ids) {
+        return judgeRepository.findAllById(ids);
+    }
     
 
     /**

--- a/src/main/java/com/dineth/debateTracker/motion/MotionService.java
+++ b/src/main/java/com/dineth/debateTracker/motion/MotionService.java
@@ -14,7 +14,7 @@ public class MotionService {
         this.motionRepository = motionRepository;
     }
 
-    public List<Motion> getMotion() {
+    public List<Motion> getMotions() {
         return motionRepository.findAll();
     }
 

--- a/src/main/java/com/dineth/debateTracker/motion/MotionService.java
+++ b/src/main/java/com/dineth/debateTracker/motion/MotionService.java
@@ -2,6 +2,7 @@ package com.dineth.debateTracker.motion;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import java.util.Collection;
 import java.util.List;
 
 @Service
@@ -20,6 +21,10 @@ public class MotionService {
 
     public Motion findMotionById(Long id) {
         return motionRepository.findById(id).orElse(null);
+    }
+
+    public List<Motion> findAllMotionsByIds(Collection<Long> ids) {
+        return motionRepository.findAllById(ids);
     }
     public Motion addMotion(Motion motion) {
         return motionRepository.save(motion);

--- a/src/main/java/com/dineth/debateTracker/team/TeamService.java
+++ b/src/main/java/com/dineth/debateTracker/team/TeamService.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.List;
 
 @Service
@@ -26,6 +27,10 @@ public class TeamService {
 
     public Team findTeamById(Long id) {
         return teamRepository.findById(id).orElse(null);
+    }
+
+    public List<Team> findAllTeamsByIds(Collection<Long> ids) {
+        return teamRepository.findAllById(ids);
     }
 
     public List<Team> getTeamsByDebater(Long debaterId) {

--- a/src/main/java/com/dineth/debateTracker/team/TeamService.java
+++ b/src/main/java/com/dineth/debateTracker/team/TeamService.java
@@ -17,7 +17,7 @@ public class TeamService {
         this.teamRepository = teamRepository;
     }
 
-    public List<Team> getTeam() {
+    public List<Team> getTeams() {
         return teamRepository.findAll();
     }
 

--- a/src/main/java/com/dineth/debateTracker/utils/ParseTabbycatXML.java
+++ b/src/main/java/com/dineth/debateTracker/utils/ParseTabbycatXML.java
@@ -37,7 +37,7 @@ public class ParseTabbycatXML {
         }
     }
 
-    public TournamentDTO getTournamentDTO(Document document) {
+    public TournamentDTO getTournamentDTO() {
         try {
             Node tournament = document.getElementsByTagName("tournament").item(0);
             String fullName = tournament.getAttributes().getNamedItem("name").getNodeValue();
@@ -49,7 +49,7 @@ public class ParseTabbycatXML {
         }
     }
 
-    public List<BreakCategoryDTO> getBreakCategoryDTOs(Document document) {
+    public List<BreakCategoryDTO> getBreakCategoryDTOs() {
         try {
             NodeList breakCategoryList = document.getElementsByTagName("break-category");
             List<BreakCategoryDTO> breakCategoryDTOs = new ArrayList<>();
@@ -70,7 +70,7 @@ public class ParseTabbycatXML {
 
     }
 
-    public List<TeamDTO> getTeamDTOs(Document document) {
+    public List<TeamDTO> getTeamDTOs() {
         try {
             NodeList teamList = document.getElementsByTagName("team");
             List<TeamDTO> teamDTOs = new ArrayList<>();
@@ -127,7 +127,7 @@ public class ParseTabbycatXML {
         }
     }
 
-    public List<JudgeDTO> getJudgeDTOs(Document document) {
+    public List<JudgeDTO> getJudgeDTOs() {
         try {
             NodeList adjudicatorList = document.getElementsByTagName("adjudicator");
             List<JudgeDTO> judgeDTOs = new ArrayList<>();
@@ -206,7 +206,7 @@ public class ParseTabbycatXML {
 
     }
 
-    public List<InstitutionDTO> getInstitutionDTOs(Document document) {
+    public List<InstitutionDTO> getInstitutionDTOs() {
         try {
             NodeList institutionList = document.getElementsByTagName("institution");
             List<InstitutionDTO> institutionDTOs = new ArrayList<>();
@@ -229,7 +229,7 @@ public class ParseTabbycatXML {
         }
     }
 
-    public List<MotionDTO> getMotionDTOs(Document document) {
+    public List<MotionDTO> getMotionDTOs() {
         try {
             List<MotionDTO> motionDTOs = new ArrayList<>();
             NodeList motionList = document.getElementsByTagName("motion");
@@ -265,7 +265,7 @@ public class ParseTabbycatXML {
         }
     }
 
-    public List<RoundDTO> getRoundsDTO(Document document) {
+    public List<RoundDTO> getRoundsDTO() {
         try {
             List<RoundDTO> roundDTOs = new ArrayList<>();
             NodeList roundList = document.getElementsByTagName("round");

--- a/src/test/java/com/dineth/debateTracker/e2e/BaseE2ETest.java
+++ b/src/test/java/com/dineth/debateTracker/e2e/BaseE2ETest.java
@@ -31,7 +31,7 @@ public abstract class BaseE2ETest {
     private static final Logger log = LoggerFactory.getLogger(BaseE2ETest.class);
 
     @Autowired
-    protected TournamentBuilder tournamentBuilder;
+    protected TournamentImportService importService;
 
     @Autowired
     protected TournamentService tournamentService;
@@ -51,7 +51,7 @@ public abstract class BaseE2ETest {
      */
     protected TournamentInfo buildTournament(String xmlPath, String tournamentName) {
         log.info("Building {} from {}...", tournamentName, xmlPath);
-        TournamentDataDTO data = tournamentBuilder.buildMyTournament(xmlPath);
+        TournamentDataDTO data = importService.importTournament(xmlPath);
         Long tournamentId = findTournamentId(tournamentService, data);
         log.info("✓ {} built successfully with ID: {}", tournamentName, tournamentId);
         

--- a/src/test/java/com/dineth/debateTracker/e2e/ControllerIntegrationTest.java
+++ b/src/test/java/com/dineth/debateTracker/e2e/ControllerIntegrationTest.java
@@ -33,7 +33,7 @@ class ControllerIntegrationTest extends BaseE2ETest {
     private static TournamentInfo tournament3;
 
     @BeforeAll
-    static void buildTournaments(@Autowired TournamentBuilder builder, 
+    static void buildTournaments(@Autowired TournamentImportService importService,
                                  @Autowired TournamentService tournamentService,
                                  @Autowired DebaterService debaterService,
                                  @Autowired JudgeService judgeService) {
@@ -41,15 +41,15 @@ class ControllerIntegrationTest extends BaseE2ETest {
         log.info("Building tournaments for controller integration tests...");
         log.info("========================================");
 
-        TournamentDataDTO data1 = builder.buildMyTournament(TestFixtures.TOURNAMENT_1_XML);
+        TournamentDataDTO data1 = importService.importTournament(TestFixtures.TOURNAMENT_1_XML);
         tournament1 = new TournamentInfo(data1, findTournamentId(tournamentService, data1));
         log.info("✓ Tournament 1 built with ID: {}", tournament1.getId());
 
-        TournamentDataDTO data2 = builder.buildMyTournament(TestFixtures.TOURNAMENT_2_XML);
+        TournamentDataDTO data2 = importService.importTournament(TestFixtures.TOURNAMENT_2_XML);
         tournament2 = new TournamentInfo(data2, findTournamentId(tournamentService, data2));
         log.info("✓ Tournament 2 built with ID: {}", tournament2.getId());
 
-        TournamentDataDTO data3 = builder.buildMyTournament(TestFixtures.TOURNAMENT_3_XML);
+        TournamentDataDTO data3 = importService.importTournament(TestFixtures.TOURNAMENT_3_XML);
         tournament3 = new TournamentInfo(data3, findTournamentId(tournamentService, data3));
         log.info("✓ Tournament 3 built with ID: {}", tournament3.getId());
 

--- a/src/test/java/com/dineth/debateTracker/e2e/ProfileAndStatisticsE2ETest.java
+++ b/src/test/java/com/dineth/debateTracker/e2e/ProfileAndStatisticsE2ETest.java
@@ -70,7 +70,7 @@ class ProfileAndStatisticsE2ETest extends BaseE2ETest {
     );
 
     @BeforeAll
-    static void buildTournaments(@Autowired TournamentBuilder builder, 
+    static void buildTournaments(@Autowired TournamentImportService importService,
                                  @Autowired TournamentService tournamentService,
                                  @Autowired DebaterService debaterService,
                                  @Autowired JudgeService judgeService) {
@@ -78,15 +78,15 @@ class ProfileAndStatisticsE2ETest extends BaseE2ETest {
         log.info("Building tournaments for profile and statistics tests...");
         log.info("========================================");
 
-        TournamentDataDTO data1 = builder.buildMyTournament(TestFixtures.TOURNAMENT_1_XML);
+        TournamentDataDTO data1 = importService.importTournament(TestFixtures.TOURNAMENT_1_XML);
         tournament1 = new TournamentInfo(data1, findTournamentId(tournamentService, data1));
         log.info("✓ Tournament 1 built with ID: {}", tournament1.getId());
 
-        TournamentDataDTO data2 = builder.buildMyTournament(TestFixtures.TOURNAMENT_2_XML);
+        TournamentDataDTO data2 = importService.importTournament(TestFixtures.TOURNAMENT_2_XML);
         tournament2 = new TournamentInfo(data2, findTournamentId(tournamentService, data2));
         log.info("✓ Tournament 2 built with ID: {}", tournament2.getId());
 
-        TournamentDataDTO data3 = builder.buildMyTournament(TestFixtures.TOURNAMENT_3_XML);
+        TournamentDataDTO data3 = importService.importTournament(TestFixtures.TOURNAMENT_3_XML);
         tournament3 = new TournamentInfo(data3, findTournamentId(tournamentService, data3));
         log.info("✓ Tournament 3 built with ID: {}", tournament3.getId());
 

--- a/src/test/java/com/dineth/debateTracker/e2e/TournamentDataE2ETest.java
+++ b/src/test/java/com/dineth/debateTracker/e2e/TournamentDataE2ETest.java
@@ -65,12 +65,12 @@ class TournamentDataE2ETest extends BaseE2ETest {
     private static TournamentInfo tournament1;
 
     @BeforeAll
-    static void buildTournament(@Autowired TournamentBuilder builder, @Autowired TournamentService tournamentService) {
+    static void buildTournament(@Autowired TournamentImportService importService, @Autowired TournamentService tournamentService) {
         log.info("========================================");
         log.info("Building tournament for data verification tests...");
         log.info("========================================");
 
-        TournamentDataDTO data = builder.buildMyTournament(TestFixtures.TOURNAMENT_1_XML);
+        TournamentDataDTO data = importService.importTournament(TestFixtures.TOURNAMENT_1_XML);
         Long tournamentId = findTournamentId(tournamentService, data);
 
         tournament1 = new TournamentInfo(data, tournamentId);
@@ -104,7 +104,7 @@ class TournamentDataE2ETest extends BaseE2ETest {
     void testTeamsCreated() {
         log.info("Test 2: Verifying teams...");
 
-        List<Team> teams = teamService.getTeam();
+        List<Team> teams = teamService.getTeams();
         assertEquals(TestFixtures.Tournament1.EXPECTED_TEAMS, teams.size(),
                 "Should have expected number of teams");
 
@@ -254,7 +254,7 @@ class TournamentDataE2ETest extends BaseE2ETest {
     void testTeamDebaterComposition() {
         log.info("Test 11: Verifying team-debater composition...");
 
-        List<Team> teams = teamService.getTeam();
+        List<Team> teams = teamService.getTeams();
         
         // Verify each team has debaters
         for (Team team : teams) {

--- a/src/test/java/com/dineth/debateTracker/utils/ParseTabbycatXMLTest.java
+++ b/src/test/java/com/dineth/debateTracker/utils/ParseTabbycatXMLTest.java
@@ -30,7 +30,7 @@ class ParseTabbycatXMLTest {
 
     @Test
     void testGetTournamentDTO() {
-        TournamentDTO dto = parser.getTournamentDTO(document);
+        TournamentDTO dto = parser.getTournamentDTO();
         assertEquals("Shanthi Peiris Memorial Debating Championship 2024", dto.getFullName(),
                 "Full name of the tournament should match");
         assertEquals("Metho 24", dto.getShortName(), "Short name of the tournament should match");
@@ -38,7 +38,7 @@ class ParseTabbycatXMLTest {
 
     @Test
     void testGetBreakCategoryDTOs() {
-        List<BreakCategoryDTO> breakCategories = parser.getBreakCategoryDTOs(document);
+        List<BreakCategoryDTO> breakCategories = parser.getBreakCategoryDTOs();
         assertNotNull(breakCategories, "Break categories list should not be null");
         assertFalse(breakCategories.isEmpty(), "Break categories list should not be empty");
 
@@ -50,7 +50,7 @@ class ParseTabbycatXMLTest {
 
     @Test
     void testGetTeamDTOs() {
-        List<TeamDTO> teams = parser.getTeamDTOs(document);
+        List<TeamDTO> teams = parser.getTeamDTOs();
         assertNotNull(teams, "Teams list should not be null");
         assertFalse(teams.isEmpty(), "Teams list should not be empty");
 
@@ -76,7 +76,7 @@ class ParseTabbycatXMLTest {
 
     @Test
     void testGetDebaterDTOs() {
-        List<TeamDTO> teams = parser.getTeamDTOs(document);
+        List<TeamDTO> teams = parser.getTeamDTOs();
         if (!teams.isEmpty()) {
 
             int totalDebaters = teams.stream().mapToInt(team -> team.getDebaters().size()).sum();
@@ -107,7 +107,7 @@ class ParseTabbycatXMLTest {
 
     @Test
     void testGetJudgeDTOs() {
-        List<JudgeDTO> judges = parser.getJudgeDTOs(document);
+        List<JudgeDTO> judges = parser.getJudgeDTOs();
         int nJudges = 47; // Expected number of judges in the tournament
         assertEquals(nJudges, judges.size(), "There should be " + nJudges + " judges in the tournament");
 
@@ -135,7 +135,7 @@ class ParseTabbycatXMLTest {
 
     @Test
     void testGetInstitutionDTOs() {
-        List<InstitutionDTO> institutions = parser.getInstitutionDTOs(document);
+        List<InstitutionDTO> institutions = parser.getInstitutionDTOs();
         int nInstitutions = 24; // Expected number of institutions in the tournament
         assertEquals(nInstitutions, institutions.size(),
                 "There should be " + nInstitutions + " institutions in the tournament");
@@ -148,7 +148,7 @@ class ParseTabbycatXMLTest {
 
     @Test
     void testGetMotionDTOs() {
-        List<MotionDTO> motions = parser.getMotionDTOs(document);
+        List<MotionDTO> motions = parser.getMotionDTOs();
 
         MotionDTO motion1 = motions.get(8);
         assertEquals("M9", motion1.getId());
@@ -171,7 +171,7 @@ class ParseTabbycatXMLTest {
 
     @Test
     void testGetRoundsDTO() {
-        List<RoundDTO> rounds = parser.getRoundsDTO(document);
+        List<RoundDTO> rounds = parser.getRoundsDTO();
 
         int nRounds = 9; // Expected number of rounds in the tournament
         assertEquals(nRounds, rounds.size(), "There should be " + nRounds + " rounds in the tournament");


### PR DESCRIPTION
This pull request introduces a comprehensive new agent reference document and implements a robust `TournamentImportService` for importing Tabbycat XML data into the database. The main focus is on providing clear developer documentation and encapsulating the tournament import pipeline in a dedicated, transactional Spring service.

**Documentation and Developer Guide Improvements:**

- **Agent Reference and Developer Guide:**
  - Adds a detailed `AGENTS.md` file documenting the architecture, tech stack, package layout, domain model, conventions, and common tasks for the Debate Tracker agent. This serves as a central onboarding and reference resource for developers.

**Core Application Logic:**

- **Tournament Import Pipeline:**
  - Introduces `TournamentImportService`, a Spring service that orchestrates the full import of a Tabbycat XML export. It parses the XML, persists all related entities (institutions, judges, teams, debaters, break categories, motions, rounds, debates, ballots), and returns a summary DTO. The entire process is transactional to ensure database consistency.
  - Implements in-memory caching for entities during import to avoid redundant database queries, improving performance and reliability.
  - Handles entity deduplication, linking, and relationship management according to the conventions outlined in the new documentation.

**Entity and Relationship Management:**

- **Import Logic Details:**
  - Provides helper methods for saving and linking institutions, judges, teams, debaters, motions, break categories, and rounds, ensuring all relationships are correctly established.
  - Implements logic for building debates, ballots, and determining winners for both preliminary and elimination rounds.

These changes greatly improve both the developer experience (through documentation) and the reliability and maintainability of the tournament import process.

**References:**  
- [AGENTS.mdR1-R158](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R1-R158) (documentation)  
- [src/main/java/com/dineth/debateTracker/TournamentImportService.javaR1-R388](diffhunk://#diff-9866220518a7276d828dca70db62f2b3e5ba4b4241eee29216dede56b05da3b2R1-R388) (import service and related logic)