### PR TITLE
Add validation services and DTOs for tournaments and institutions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ All entities carry `createdAt`/`updatedAt` managed by `@PrePersist`/`@PreUpdate`
 
 The whole method rolls back on any exception. XML-id→DTO maps (`debaterDTOMap`, etc.) are import-internal working state — they are **not** returned in `TournamentDataDTO`.
 
-**Dry-run validation:** `POST /api/v1/tournament/validate` (multipart `file`) → `TournamentValidationService` parses an uploaded XML and returns a `ValidationReportDTO` (`dtos/validation/`) of findings — missing/single-word names, ballot-count mismatches, empty teams, plus read-only DB cross-checks (speaker/tournament already exists). It is strictly read-only (never persists) and never throws for a bad file (a malformed upload is reported as a `PARSE_ERROR` finding). Use this to preview an import before committing one.
+**Dry-run validation:** `POST /api/v1/tournament/validate` (multipart `file`) → `TournamentValidationService` parses an uploaded XML and returns a `ValidationReportDTO` (`dtos/validation/`) of findings — missing/single-word names, ballot-count mismatches, empty teams, plus read-only DB cross-checks (speaker/tournament already exists). When a speaker name matches existing debaters, the finding carries each candidate's teams and institution (`DebaterMatch`) so a human can tell apart speakers who share a name (or whose names are misspelled / missing a last name) — single matches are `DEBATER_EXISTS` (INFO), multiple are `DEBATER_AMBIGUOUS` (WARNING). It is strictly read-only (never persists) and never throws for a bad file (a malformed upload is reported as a `PARSE_ERROR` finding). Use this to preview an import before committing one.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,9 @@ All entities carry `createdAt`/`updatedAt` managed by `@PrePersist`/`@PreUpdate`
 | File | Role |
 |---|---|
 | `TournamentImportService.java` | Reads parsed DTOs and writes all entities to the DB; the main import pipeline (runs as one transaction) |
-| `TournamentBuilder.java` | `@RestController` for `/api/v1/tournament/*`; delegates to `TournamentImportService` |
-| `utils/ParseTabbycatXML.java` | Deserializes Tabbycat XML into `dtos/xmlparsing/` DTOs |
+| `TournamentValidationService.java` | Read-only dry-run validator for uploaded XML; returns a `ValidationReportDTO` without persisting |
+| `TournamentBuilder.java` | `@RestController` for `/api/v1/tournament/*`; delegates to the import/validation services |
+| `utils/ParseTabbycatXML.java` | Deserializes Tabbycat XML into `dtos/xmlparsing/` DTOs (from a file path or an `InputStream`) |
 | `statistics/StatisticsService.java` | Percentile ranks, win/loss ratios, judge sentiment |
 | `debaterprofile/DebaterProfileService.java` | Aggregates multi-tournament debater stats into a profile |
 | `judgeprofile/JudgeProfileService.java` | Aggregates judge activity and sentiment into a profile |
@@ -92,6 +93,8 @@ All entities carry `createdAt`/`updatedAt` managed by `@PrePersist`/`@PreUpdate`
 4. `processRound` → `buildDebate` builds debates/ballots from the caches; `buildDebate` returns `null` to skip a debate (unresolved teams or ballot-count mismatch).
 
 The whole method rolls back on any exception. XML-id→DTO maps (`debaterDTOMap`, etc.) are import-internal working state — they are **not** returned in `TournamentDataDTO`.
+
+**Dry-run validation:** `POST /api/v1/tournament/validate` (multipart `file`) → `TournamentValidationService` parses an uploaded XML and returns a `ValidationReportDTO` (`dtos/validation/`) of findings — missing/single-word names, ballot-count mismatches, empty teams, plus read-only DB cross-checks (speaker/tournament already exists). It is strictly read-only (never persists) and never throws for a bad file (a malformed upload is reported as a `PARSE_ERROR` finding). Use this to preview an import before committing one.
 
 ---
 

--- a/src/main/java/com/dineth/debateTracker/TournamentBuilder.java
+++ b/src/main/java/com/dineth/debateTracker/TournamentBuilder.java
@@ -3,11 +3,14 @@ package com.dineth.debateTracker;
 import com.dineth.debateTracker.debater.Debater;
 import com.dineth.debateTracker.debater.DebaterService;
 import com.dineth.debateTracker.dtos.TournamentDataDTO;
+import com.dineth.debateTracker.dtos.validation.ValidationReportDTO;
 import com.dineth.debateTracker.dtos.xmlparsing.RoundDTO;
 import com.dineth.debateTracker.utils.ParseCSV;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -32,12 +35,24 @@ public class TournamentBuilder {
     private static final int DEFAULT_SUMMARY_YEAR = 2024;
 
     private final TournamentImportService importService;
+    private final TournamentValidationService validationService;
     private final DebaterService debaterService;
 
     @Autowired
-    public TournamentBuilder(TournamentImportService importService, DebaterService debaterService) {
+    public TournamentBuilder(TournamentImportService importService, TournamentValidationService validationService,
+            DebaterService debaterService) {
         this.importService = importService;
+        this.validationService = validationService;
         this.debaterService = debaterService;
+    }
+
+    /**
+     * Dry-run validation of an uploaded tournament XML file. Returns a structured report of warnings
+     * and errors <b>without persisting anything</b>, so a UI can preview an import before committing.
+     */
+    @PostMapping(value = "/validate", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ValidationReportDTO validateTournament(@RequestParam("file") MultipartFile file) {
+        return validationService.validate(file);
     }
 
     @GetMapping("/build")

--- a/src/main/java/com/dineth/debateTracker/TournamentValidationService.java
+++ b/src/main/java/com/dineth/debateTracker/TournamentValidationService.java
@@ -1,0 +1,249 @@
+package com.dineth.debateTracker;
+
+import com.dineth.debateTracker.debater.Debater;
+import com.dineth.debateTracker.debater.DebaterService;
+import com.dineth.debateTracker.dtos.validation.Severity;
+import com.dineth.debateTracker.dtos.validation.ValidationFinding;
+import com.dineth.debateTracker.dtos.validation.ValidationReportDTO;
+import com.dineth.debateTracker.dtos.xmlparsing.*;
+import com.dineth.debateTracker.institution.InstitutionService;
+import com.dineth.debateTracker.tournament.Tournament;
+import com.dineth.debateTracker.tournament.TournamentService;
+import com.dineth.debateTracker.utils.CustomExceptions;
+import com.dineth.debateTracker.utils.ParseTabbycatXML;
+import com.dineth.debateTracker.utils.StringUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * Dry-run validator for uploaded Tabbycat tournament XML. Parses the file and runs the same checks
+ * and lookups the importer uses, but is strictly <b>read-only</b> — it never persists anything, so it
+ * cannot affect existing data and is safe to call before a real import.
+ *
+ * <p>Returns a {@link ValidationReportDTO}; it never throws for a bad file (a malformed upload is
+ * reported as a finding, not a server error).
+ */
+@Service
+@Slf4j
+public class TournamentValidationService {
+
+    private final DebaterService debaterService;
+    private final InstitutionService institutionService;
+    private final TournamentService tournamentService;
+
+    @Autowired
+    public TournamentValidationService(DebaterService debaterService, InstitutionService institutionService,
+            TournamentService tournamentService) {
+        this.debaterService = debaterService;
+        this.institutionService = institutionService;
+        this.tournamentService = tournamentService;
+    }
+
+    @Transactional(readOnly = true)
+    public ValidationReportDTO validate(MultipartFile file) {
+        List<ValidationFinding> findings = new ArrayList<>();
+        Map<String, Integer> summary = new LinkedHashMap<>();
+
+        if (file == null || file.isEmpty()) {
+            findings.add(new ValidationFinding(Severity.ERROR, "EMPTY_FILE", "No file was uploaded or the file is empty.", "file"));
+            return new ValidationReportDTO(findings, summary);
+        }
+
+        ParseTabbycatXML parser;
+        try {
+            parser = new ParseTabbycatXML(file.getInputStream());
+            parser.parseXML();
+        } catch (Exception e) {
+            findings.add(new ValidationFinding(Severity.ERROR, "PARSE_ERROR", "Could not read the uploaded file: " + e.getMessage(), "file"));
+            return new ValidationReportDTO(findings, summary);
+        }
+
+        if (parser.document == null) {
+            findings.add(new ValidationFinding(Severity.ERROR, "PARSE_ERROR", "The file is not well-formed XML or is not a Tabbycat export.", "file"));
+            return new ValidationReportDTO(findings, summary);
+        }
+
+        TournamentDTO tournamentDTO = safeExtract(parser::getTournamentDTO, "tournament", findings);
+        List<TeamDTO> teamDTOs = safeExtractList(parser::getTeamDTOs, "teams", findings);
+        List<JudgeDTO> judgeDTOs = safeExtractList(parser::getJudgeDTOs, "adjudicators", findings);
+        List<InstitutionDTO> institutionDTOs = safeExtractList(parser::getInstitutionDTOs, "institutions", findings);
+        List<MotionDTO> motionDTOs = safeExtractList(parser::getMotionDTOs, "motions", findings);
+        List<RoundDTO> roundDTOs = safeExtractList(parser::getRoundsDTO, "rounds", findings);
+
+        buildSummary(summary, teamDTOs, judgeDTOs, institutionDTOs, motionDTOs, roundDTOs);
+
+        validateTeamsAndDebaters(teamDTOs, institutionDTOs, findings);
+        validateJudges(judgeDTOs, findings);
+        validateDebates(roundDTOs, findings);
+        crossCheckTournament(tournamentDTO, findings);
+
+        return new ValidationReportDTO(findings, summary);
+    }
+
+    // ---- Section A: XML-intrinsic checks ----------------------------------------------------------
+
+    private void validateTeamsAndDebaters(List<TeamDTO> teamDTOs, List<InstitutionDTO> institutionDTOs,
+            List<ValidationFinding> findings) {
+        Set<String> seenDebaterNames = new HashSet<>();
+        for (TeamDTO teamDTO : teamDTOs) {
+            String teamLabel = "team '" + teamDTO.getName() + "'";
+            List<DebaterDTO> debaters = teamDTO.getDebaters();
+            if (debaters == null || debaters.isEmpty()) {
+                findings.add(new ValidationFinding(Severity.WARNING, "EMPTY_TEAM", "Team has no speakers.", teamLabel));
+                continue;
+            }
+            checkMissingInstitution(teamDTO, debaters, institutionDTOs, findings, teamLabel);
+            for (DebaterDTO debaterDTO : debaters) {
+                String location = teamLabel + " speaker '" + debaterDTO.getName() + "'";
+                checkName(debaterDTO.getName(), location, findings);
+                // read-only DB cross-check, once per distinct name
+                if (debaterDTO.getName() != null && seenDebaterNames.add(debaterDTO.getName())) {
+                    crossCheckDebater(debaterDTO.getName(), location, findings);
+                }
+            }
+        }
+    }
+
+    private void checkMissingInstitution(TeamDTO teamDTO, List<DebaterDTO> debaters,
+            List<InstitutionDTO> institutionDTOs, List<ValidationFinding> findings, String teamLabel) {
+        String institutionId = debaters.get(0).getInstitutionId();
+        if (institutionId == null || institutionId.isEmpty()) {
+            findings.add(new ValidationFinding(Severity.INFO, "MISSING_INSTITUTION", "Team has no institution; it will not be linked to one.", teamLabel));
+            return;
+        }
+        boolean known = institutionDTOs.stream().anyMatch(inst -> institutionId.equals(inst.getId()));
+        if (!known) {
+            findings.add(new ValidationFinding(Severity.WARNING, "MISSING_INSTITUTION",
+                    "Team references institution id '" + institutionId + "' that is not declared in the file.", teamLabel));
+        }
+    }
+
+    private void validateJudges(List<JudgeDTO> judgeDTOs, List<ValidationFinding> findings) {
+        for (JudgeDTO judgeDTO : judgeDTOs) {
+            checkName(judgeDTO.getName(), "adjudicator '" + judgeDTO.getName() + "'", findings);
+        }
+    }
+
+    private void validateDebates(List<RoundDTO> roundDTOs, List<ValidationFinding> findings) {
+        for (RoundDTO roundDTO : roundDTOs) {
+            List<DebateDTO> debates = roundDTO.getDebates();
+            if (debates == null) {
+                continue;
+            }
+            for (DebateDTO debateDTO : debates) {
+                List<SideDTO> sides = debateDTO.getSides();
+                if (sides == null || sides.size() < 2) {
+                    findings.add(new ValidationFinding(Severity.WARNING, "INCOMPLETE_DEBATE",
+                            "Debate does not have two sides; it will be skipped on import.", "round '" + roundDTO.getName() + "'"));
+                    continue;
+                }
+                int propBallots = sides.get(0).getFinalTeamBallots().size();
+                int oppBallots = sides.get(1).getFinalTeamBallots().size();
+                if (propBallots != oppBallots) {
+                    findings.add(new ValidationFinding(Severity.WARNING, "BALLOT_COUNT_MISMATCH",
+                            "Ballot count mismatch (prop=" + propBallots + ", opp=" + oppBallots + "); this debate will be skipped on import.",
+                            "round '" + roundDTO.getName() + "'"));
+                }
+            }
+        }
+    }
+
+    /**
+     * Reuses {@link StringUtil#splitName} so name rules stay single-sourced: an empty/null name throws
+     * (reported as an error), and a single-token name yields an empty last name (reported as a warning).
+     */
+    private void checkName(String name, String location, List<ValidationFinding> findings) {
+        try {
+            ImmutablePair<String, String> names = StringUtil.splitName(name);
+            if (names.getRight() == null || names.getRight().isEmpty()) {
+                findings.add(new ValidationFinding(Severity.WARNING, "MISSING_LAST_NAME",
+                        "Name '" + name + "' has no last name.", location));
+            }
+        } catch (CustomExceptions.NameSplitException e) {
+            findings.add(new ValidationFinding(Severity.ERROR, "MISSING_NAME", "Name is missing or empty.", location));
+        }
+    }
+
+    // ---- Section B: read-only DB cross-checks -----------------------------------------------------
+
+    private void crossCheckDebater(String name, String location, List<ValidationFinding> findings) {
+        ImmutablePair<String, String> names;
+        try {
+            names = StringUtil.splitName(name);
+        } catch (CustomExceptions.NameSplitException e) {
+            return; // already reported as MISSING_NAME
+        }
+        Debater probe = new Debater(StringUtil.capitalizeName(names.getLeft()), StringUtil.capitalizeName(names.getRight()));
+        try {
+            Debater existing = debaterService.checkIfDebaterExists(probe);
+            if (existing != null) {
+                findings.add(new ValidationFinding(Severity.INFO, "DEBATER_EXISTS",
+                        "A speaker named '" + name + "' already exists and will be reused, not created.", location));
+            }
+        } catch (CustomExceptions.MultipleDebatersFoundException e) {
+            findings.add(new ValidationFinding(Severity.WARNING, "DEBATER_AMBIGUOUS",
+                    "Multiple existing speakers match '" + name + "'; a birthdate is needed to disambiguate on import.", location));
+        }
+    }
+
+    private void crossCheckTournament(TournamentDTO tournamentDTO, List<ValidationFinding> findings) {
+        if (tournamentDTO == null || tournamentDTO.getShortName() == null) {
+            return;
+        }
+        boolean exists = tournamentService.getTournaments().stream()
+                .anyMatch(t -> tournamentDTO.getShortName().equals(t.getShortName()));
+        if (exists) {
+            findings.add(new ValidationFinding(Severity.WARNING, "TOURNAMENT_EXISTS",
+                    "A tournament with short name '" + tournamentDTO.getShortName() + "' already exists; importing may create a duplicate.",
+                    "tournament '" + tournamentDTO.getShortName() + "'"));
+        }
+    }
+
+    // ---- helpers ---------------------------------------------------------------------------------
+
+    private void buildSummary(Map<String, Integer> summary, List<TeamDTO> teamDTOs, List<JudgeDTO> judgeDTOs,
+            List<InstitutionDTO> institutionDTOs, List<MotionDTO> motionDTOs, List<RoundDTO> roundDTOs) {
+        int debaters = teamDTOs.stream().mapToInt(t -> t.getDebaters() != null ? t.getDebaters().size() : 0).sum();
+        int debates = roundDTOs.stream().mapToInt(r -> r.getDebates() != null ? r.getDebates().size() : 0).sum();
+        summary.put("teams", teamDTOs.size());
+        summary.put("debaters", debaters);
+        summary.put("judges", judgeDTOs.size());
+        summary.put("institutions", institutionDTOs.size());
+        summary.put("motions", motionDTOs.size());
+        summary.put("rounds", roundDTOs.size());
+        summary.put("debates", debates);
+    }
+
+    private <T> List<T> safeExtractList(Supplier<List<T>> supplier, String section, List<ValidationFinding> findings) {
+        try {
+            List<T> result = supplier.get();
+            return result != null ? result : List.of();
+        } catch (Exception e) {
+            findings.add(new ValidationFinding(Severity.ERROR, "PARSE_ERROR",
+                    "Failed to parse " + section + ": " + e.getMessage(), section));
+            return List.of();
+        }
+    }
+
+    private <T> T safeExtract(Supplier<T> supplier, String section, List<ValidationFinding> findings) {
+        try {
+            return supplier.get();
+        } catch (Exception e) {
+            findings.add(new ValidationFinding(Severity.ERROR, "PARSE_ERROR",
+                    "Failed to parse " + section + ": " + e.getMessage(), section));
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/dineth/debateTracker/TournamentValidationService.java
+++ b/src/main/java/com/dineth/debateTracker/TournamentValidationService.java
@@ -3,6 +3,7 @@ package com.dineth.debateTracker;
 import com.dineth.debateTracker.debater.Debater;
 import com.dineth.debateTracker.debater.DebaterService;
 import com.dineth.debateTracker.dtos.validation.DebaterMatch;
+import com.dineth.debateTracker.dtos.validation.InstitutionMatch;
 import com.dineth.debateTracker.dtos.validation.Severity;
 import com.dineth.debateTracker.dtos.validation.ValidationFinding;
 import com.dineth.debateTracker.dtos.validation.ValidationReportDTO;
@@ -93,6 +94,7 @@ public class TournamentValidationService {
         validateTeamsAndDebaters(teamDTOs, institutionDTOs, findings);
         validateJudges(judgeDTOs, findings);
         validateDebates(roundDTOs, findings);
+        crossCheckInstitutions(institutionDTOs, findings);
         crossCheckTournament(tournamentDTO, findings);
 
         return new ValidationReportDTO(findings, summary);
@@ -237,6 +239,34 @@ public class TournamentValidationService {
         return matches.stream()
                 .map(match -> "#" + match.debaterId() + " [" + describe(match) + "]")
                 .collect(Collectors.joining("; "));
+    }
+
+    /**
+     * Mirrors {@link TournamentImportService}'s institution handling: the importer reuses an existing
+     * institution when {@link InstitutionService#findInstitutionByName} matches one, otherwise creates
+     * it. This surfaces each reuse so a human can confirm the upload will be linked to the right
+     * existing institution (and catch an unintended merge when the stored spelling differs).
+     */
+    private void crossCheckInstitutions(List<InstitutionDTO> institutionDTOs, List<ValidationFinding> findings) {
+        for (InstitutionDTO institutionDTO : institutionDTOs) {
+            String name = institutionDTO.getName();
+            if (name == null || name.isBlank()) {
+                continue;
+            }
+            String stripped = name.strip();
+            Institution existing = institutionService.findInstitutionByName(stripped);
+            if (existing == null) {
+                continue; // a new institution will be created on import; nothing to flag
+            }
+            InstitutionMatch match = new InstitutionMatch(existing.getId(), existing.getName(), existing.getAbbreviation());
+            String reused = existing.getName() != null ? existing.getName() : stripped;
+            String note = reused.equalsIgnoreCase(stripped)
+                    ? "'" + stripped + "' already exists and will be reused, not created."
+                    : "'" + stripped + "' will be matched to existing '" + reused + "' (#" + existing.getId()
+                            + ") and reused, not created — confirm this is the same institution.";
+            findings.add(new ValidationFinding(Severity.INFO, "INSTITUTION_MATCH", "Institution " + note,
+                    "institution '" + stripped + "'", match));
+        }
     }
 
     private void crossCheckTournament(TournamentDTO tournamentDTO, List<ValidationFinding> findings) {

--- a/src/main/java/com/dineth/debateTracker/TournamentValidationService.java
+++ b/src/main/java/com/dineth/debateTracker/TournamentValidationService.java
@@ -2,12 +2,15 @@ package com.dineth.debateTracker;
 
 import com.dineth.debateTracker.debater.Debater;
 import com.dineth.debateTracker.debater.DebaterService;
+import com.dineth.debateTracker.dtos.validation.DebaterMatch;
 import com.dineth.debateTracker.dtos.validation.Severity;
 import com.dineth.debateTracker.dtos.validation.ValidationFinding;
 import com.dineth.debateTracker.dtos.validation.ValidationReportDTO;
 import com.dineth.debateTracker.dtos.xmlparsing.*;
+import com.dineth.debateTracker.institution.Institution;
 import com.dineth.debateTracker.institution.InstitutionService;
-import com.dineth.debateTracker.tournament.Tournament;
+import com.dineth.debateTracker.team.Team;
+import com.dineth.debateTracker.team.TeamService;
 import com.dineth.debateTracker.tournament.TournamentService;
 import com.dineth.debateTracker.utils.CustomExceptions;
 import com.dineth.debateTracker.utils.ParseTabbycatXML;
@@ -26,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Dry-run validator for uploaded Tabbycat tournament XML. Parses the file and runs the same checks
@@ -42,13 +46,15 @@ public class TournamentValidationService {
     private final DebaterService debaterService;
     private final InstitutionService institutionService;
     private final TournamentService tournamentService;
+    private final TeamService teamService;
 
     @Autowired
     public TournamentValidationService(DebaterService debaterService, InstitutionService institutionService,
-            TournamentService tournamentService) {
+            TournamentService tournamentService, TeamService teamService) {
         this.debaterService = debaterService;
         this.institutionService = institutionService;
         this.tournamentService = tournamentService;
+        this.teamService = teamService;
     }
 
     @Transactional(readOnly = true)
@@ -185,17 +191,52 @@ public class TournamentValidationService {
         } catch (CustomExceptions.NameSplitException e) {
             return; // already reported as MISSING_NAME
         }
-        Debater probe = new Debater(StringUtil.capitalizeName(names.getLeft()), StringUtil.capitalizeName(names.getRight()));
-        try {
-            Debater existing = debaterService.checkIfDebaterExists(probe);
-            if (existing != null) {
-                findings.add(new ValidationFinding(Severity.INFO, "DEBATER_EXISTS",
-                        "A speaker named '" + name + "' already exists and will be reused, not created.", location));
-            }
-        } catch (CustomExceptions.MultipleDebatersFoundException e) {
-            findings.add(new ValidationFinding(Severity.WARNING, "DEBATER_AMBIGUOUS",
-                    "Multiple existing speakers match '" + name + "'; a birthdate is needed to disambiguate on import.", location));
+        String first = StringUtil.capitalizeName(names.getLeft());
+        String last = StringUtil.capitalizeName(names.getRight());
+        List<Debater> existing = debaterService.findDebatersByName(first, last);
+        if (existing.isEmpty()) {
+            return;
         }
+        // Attach each existing debater's teams + institution so a human can tell apart speakers who
+        // share a name (or whose names are misspelled / missing a last name).
+        List<DebaterMatch> matches = existing.stream().map(this::toMatch).collect(Collectors.toList());
+        if (existing.size() == 1) {
+            findings.add(new ValidationFinding(Severity.INFO, "DEBATER_EXISTS",
+                    "A speaker named '" + name + "' already exists (" + describe(matches.get(0))
+                            + ") and will be reused, not created.",
+                    location, matches));
+        } else {
+            findings.add(new ValidationFinding(Severity.WARNING, "DEBATER_AMBIGUOUS",
+                    "Multiple existing speakers match '" + name + "' — " + summarize(matches)
+                            + ". A birthdate is needed to disambiguate on import; compare the teams/institution to identify the right one.",
+                    location, matches));
+        }
+    }
+
+    /** Builds disambiguating context (teams + institution) for an existing debater. */
+    private DebaterMatch toMatch(Debater debater) {
+        Institution institution = debater.getInstitution();
+        String institutionName = institution != null ? institution.getName() : null;
+        List<String> teams = teamService.getTeamsByDebater(debater.getId()).stream()
+                .map(Team::getTeamName)
+                .filter(teamName -> teamName != null && !teamName.isEmpty())
+                .distinct()
+                .collect(Collectors.toList());
+        String storedName = ((debater.getFirstName() != null ? debater.getFirstName() : "") + " "
+                + (debater.getLastName() != null ? debater.getLastName() : "")).trim();
+        return new DebaterMatch(debater.getId(), storedName, institutionName, teams);
+    }
+
+    private String describe(DebaterMatch match) {
+        String institution = match.institution() != null ? match.institution() : "no institution";
+        String teams = match.teams().isEmpty() ? "no recorded teams" : "teams: " + String.join(", ", match.teams());
+        return institution + "; " + teams;
+    }
+
+    private String summarize(List<DebaterMatch> matches) {
+        return matches.stream()
+                .map(match -> "#" + match.debaterId() + " [" + describe(match) + "]")
+                .collect(Collectors.joining("; "));
     }
 
     private void crossCheckTournament(TournamentDTO tournamentDTO, List<ValidationFinding> findings) {

--- a/src/main/java/com/dineth/debateTracker/debater/DebaterService.java
+++ b/src/main/java/com/dineth/debateTracker/debater/DebaterService.java
@@ -60,6 +60,16 @@ public class DebaterService {
         return debaterRepository.findDebatersByInstitutionId(institutionId);
     }
 
+    /**
+     * Returns every debater matching the given name, case-insensitively. Unlike
+     * {@link #checkIfDebaterExists(Debater)} this never throws on ambiguity — it is meant for
+     * read-only previews (e.g. validation) that want to show all candidates so a human can
+     * disambiguate by their teams/institution.
+     */
+    public List<Debater> findDebatersByName(String firstName, String lastName) {
+        return debaterRepository.findByFirstNameAndLastNameAllIgnoreCase(firstName, lastName);
+    }
+
     public Debater checkIfDebaterExists(Debater debater) {
         List<Debater> debaters;
         if (debater.getBirthdate() != null) {

--- a/src/main/java/com/dineth/debateTracker/dtos/validation/DebaterMatch.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/validation/DebaterMatch.java
@@ -1,0 +1,17 @@
+package com.dineth.debateTracker.dtos.validation;
+
+import java.util.List;
+
+/**
+ * Identifying context for an existing debater in the DB that an uploaded name matched. Surfaced on
+ * {@code DEBATER_EXISTS}/{@code DEBATER_AMBIGUOUS} findings so a human can tell apart speakers who
+ * share a name (or whose names are misspelled / missing a last name) by the teams and institution
+ * they have previously been part of.
+ *
+ * @param debaterId   the existing debater's id
+ * @param name        the existing debater's stored name
+ * @param institution the existing debater's institution name, or {@code null} if none is recorded
+ * @param teams       the names of teams this debater has been part of (may be empty)
+ */
+public record DebaterMatch(Long debaterId, String name, String institution, List<String> teams) {
+}

--- a/src/main/java/com/dineth/debateTracker/dtos/validation/InstitutionMatch.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/validation/InstitutionMatch.java
@@ -1,0 +1,14 @@
+package com.dineth.debateTracker.dtos.validation;
+
+/**
+ * Identifying context for an existing institution in the DB that an uploaded institution matched.
+ * Surfaced on {@code INSTITUTION_MATCH} findings so a human can confirm that an uploaded institution
+ * will be reused (the import will link teams to this existing institution rather than create a new
+ * one), and catch an unintended merge when the stored name differs from the uploaded spelling.
+ *
+ * @param institutionId the existing institution's id
+ * @param name          the existing institution's stored name
+ * @param abbreviation  the existing institution's abbreviation, or {@code null} if none is recorded
+ */
+public record InstitutionMatch(Long institutionId, String name, String abbreviation) {
+}

--- a/src/main/java/com/dineth/debateTracker/dtos/validation/Severity.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/validation/Severity.java
@@ -1,0 +1,11 @@
+package com.dineth.debateTracker.dtos.validation;
+
+/**
+ * Severity of a {@link ValidationFinding}. A report is considered invalid only if it contains
+ * at least one {@link #ERROR}.
+ */
+public enum Severity {
+    ERROR,
+    WARNING,
+    INFO
+}

--- a/src/main/java/com/dineth/debateTracker/dtos/validation/ValidationFinding.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/validation/ValidationFinding.java
@@ -1,0 +1,12 @@
+package com.dineth.debateTracker.dtos.validation;
+
+/**
+ * A single issue discovered while validating an uploaded tournament XML file.
+ *
+ * @param severity how serious the issue is
+ * @param code     a stable machine-readable code (e.g. {@code MISSING_LAST_NAME}) for the UI to switch on
+ * @param message  a human-readable description
+ * @param location a human-readable pointer to where the issue is (e.g. {@code "team 'Foo' debater 'John'"})
+ */
+public record ValidationFinding(Severity severity, String code, String message, String location) {
+}

--- a/src/main/java/com/dineth/debateTracker/dtos/validation/ValidationFinding.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/validation/ValidationFinding.java
@@ -1,5 +1,7 @@
 package com.dineth.debateTracker.dtos.validation;
 
+import java.util.List;
+
 /**
  * A single issue discovered while validating an uploaded tournament XML file.
  *
@@ -7,6 +9,14 @@ package com.dineth.debateTracker.dtos.validation;
  * @param code     a stable machine-readable code (e.g. {@code MISSING_LAST_NAME}) for the UI to switch on
  * @param message  a human-readable description
  * @param location a human-readable pointer to where the issue is (e.g. {@code "team 'Foo' debater 'John'"})
+ * @param matches  for debater cross-checks, the existing DB debaters this name matched, with the teams
+ *                 and institution that disambiguate them; empty for findings that carry no candidates
  */
-public record ValidationFinding(Severity severity, String code, String message, String location) {
+public record ValidationFinding(Severity severity, String code, String message, String location,
+        List<DebaterMatch> matches) {
+
+    /** Convenience constructor for findings that carry no debater candidates. */
+    public ValidationFinding(Severity severity, String code, String message, String location) {
+        this(severity, code, message, location, List.of());
+    }
 }

--- a/src/main/java/com/dineth/debateTracker/dtos/validation/ValidationFinding.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/validation/ValidationFinding.java
@@ -5,18 +5,32 @@ import java.util.List;
 /**
  * A single issue discovered while validating an uploaded tournament XML file.
  *
- * @param severity how serious the issue is
- * @param code     a stable machine-readable code (e.g. {@code MISSING_LAST_NAME}) for the UI to switch on
- * @param message  a human-readable description
- * @param location a human-readable pointer to where the issue is (e.g. {@code "team 'Foo' debater 'John'"})
- * @param matches  for debater cross-checks, the existing DB debaters this name matched, with the teams
- *                 and institution that disambiguate them; empty for findings that carry no candidates
+ * @param severity        how serious the issue is
+ * @param code            a stable machine-readable code (e.g. {@code MISSING_LAST_NAME}) for the UI to switch on
+ * @param message         a human-readable description
+ * @param location        a human-readable pointer to where the issue is (e.g. {@code "team 'Foo' debater 'John'"})
+ * @param matches         for debater cross-checks, the existing DB debaters this name matched, with the teams
+ *                        and institution that disambiguate them; empty for findings that carry no candidates
+ * @param institutionMatch for institution cross-checks, the existing DB institution this name will be reused
+ *                        as; {@code null} for findings that carry no institution candidate
  */
 public record ValidationFinding(Severity severity, String code, String message, String location,
-        List<DebaterMatch> matches) {
+        List<DebaterMatch> matches, InstitutionMatch institutionMatch) {
 
-    /** Convenience constructor for findings that carry no debater candidates. */
+    /** Convenience constructor for findings that carry no candidates. */
     public ValidationFinding(Severity severity, String code, String message, String location) {
-        this(severity, code, message, location, List.of());
+        this(severity, code, message, location, List.of(), null);
+    }
+
+    /** Convenience constructor for debater cross-check findings. */
+    public ValidationFinding(Severity severity, String code, String message, String location,
+            List<DebaterMatch> matches) {
+        this(severity, code, message, location, matches, null);
+    }
+
+    /** Convenience constructor for institution cross-check findings. */
+    public ValidationFinding(Severity severity, String code, String message, String location,
+            InstitutionMatch institutionMatch) {
+        this(severity, code, message, location, List.of(), institutionMatch);
     }
 }

--- a/src/main/java/com/dineth/debateTracker/dtos/validation/ValidationReportDTO.java
+++ b/src/main/java/com/dineth/debateTracker/dtos/validation/ValidationReportDTO.java
@@ -1,0 +1,31 @@
+package com.dineth.debateTracker.dtos.validation;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Result of a dry-run validation of an uploaded tournament XML file. Produced without persisting
+ * anything. {@code valid} is true only when there are no {@link Severity#ERROR} findings.
+ */
+@Getter
+public class ValidationReportDTO {
+
+    private final boolean valid;
+    private final int errorCount;
+    private final int warningCount;
+    private final int infoCount;
+    /** Parsed entity counts (teams, debaters, judges, rounds, debates, motions), best-effort. */
+    private final Map<String, Integer> summary;
+    private final List<ValidationFinding> findings;
+
+    public ValidationReportDTO(List<ValidationFinding> findings, Map<String, Integer> summary) {
+        this.findings = findings;
+        this.summary = summary;
+        this.errorCount = (int) findings.stream().filter(f -> f.severity() == Severity.ERROR).count();
+        this.warningCount = (int) findings.stream().filter(f -> f.severity() == Severity.WARNING).count();
+        this.infoCount = (int) findings.stream().filter(f -> f.severity() == Severity.INFO).count();
+        this.valid = this.errorCount == 0;
+    }
+}

--- a/src/main/java/com/dineth/debateTracker/utils/ParseTabbycatXML.java
+++ b/src/main/java/com/dineth/debateTracker/utils/ParseTabbycatXML.java
@@ -9,6 +9,7 @@ import org.w3c.dom.NodeList;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -16,10 +17,18 @@ import java.util.List;
 @Slf4j
 public class ParseTabbycatXML {
     String xmlPath;
+    InputStream inputStream;
     public Document document;
 
     public ParseTabbycatXML(String xmlPath) {
         this.xmlPath = xmlPath;
+    }
+
+    /**
+     * Parse from an arbitrary stream (e.g. an uploaded file) instead of a file path on disk.
+     */
+    public ParseTabbycatXML(InputStream inputStream) {
+        this.inputStream = inputStream;
     }
 
     public void parseXML() {
@@ -27,7 +36,7 @@ public class ParseTabbycatXML {
             // Parse the XML file
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             DocumentBuilder builder = factory.newDocumentBuilder();
-            document = builder.parse(this.xmlPath); // Specify the path to your XML file
+            document = inputStream != null ? builder.parse(inputStream) : builder.parse(this.xmlPath);
 
             // Normalize the XML Structure
             document.getDocumentElement().normalize();

--- a/src/test/java/com/dineth/debateTracker/TournamentValidationServiceTest.java
+++ b/src/test/java/com/dineth/debateTracker/TournamentValidationServiceTest.java
@@ -81,5 +81,12 @@ class TournamentValidationServiceTest {
                         .filter(f -> "DEBATER_EXISTS".equals(f.code()))
                         .anyMatch(f -> !f.matches().isEmpty() && f.matches().stream().anyMatch(m -> !m.teams().isEmpty())),
                 "A DEBATER_EXISTS finding should carry the existing debater's team context");
+
+        // Institutions already imported should be flagged as reused (replaced by the existing one),
+        // carrying the matched institution's identity.
+        assertTrue(report.getFindings().stream()
+                        .filter(f -> "INSTITUTION_MATCH".equals(f.code()))
+                        .anyMatch(f -> f.institutionMatch() != null && f.institutionMatch().institutionId() != null),
+                "An INSTITUTION_MATCH finding should carry the existing institution's identity");
     }
 }

--- a/src/test/java/com/dineth/debateTracker/TournamentValidationServiceTest.java
+++ b/src/test/java/com/dineth/debateTracker/TournamentValidationServiceTest.java
@@ -1,0 +1,78 @@
+package com.dineth.debateTracker;
+
+import com.dineth.debateTracker.builders.TestFixtures;
+import com.dineth.debateTracker.dtos.validation.ValidationReportDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class TournamentValidationServiceTest {
+
+    @Autowired
+    private TournamentValidationService validationService;
+
+    @Autowired
+    private TournamentImportService importService;
+
+    private MockMultipartFile fileFrom(String path) throws Exception {
+        byte[] bytes = Files.readAllBytes(Path.of(path));
+        return new MockMultipartFile("file", "tournament.xml", "application/xml", bytes);
+    }
+
+    @Test
+    void realFixtureProducesValidReportWithCorrectCounts() throws Exception {
+        ValidationReportDTO report = validationService.validate(fileFrom(TestFixtures.TOURNAMENT_1_XML));
+
+        assertTrue(report.isValid(), "A real Tabbycat export should have no ERROR findings");
+        assertEquals(0, report.getErrorCount());
+        assertEquals(TestFixtures.Tournament1.EXPECTED_TEAMS, report.getSummary().get("teams").intValue());
+        assertEquals(TestFixtures.Tournament1.EXPECTED_ROUNDS, report.getSummary().get("rounds").intValue());
+        assertEquals(TestFixtures.Tournament1.EXPECTED_MOTIONS, report.getSummary().get("motions").intValue());
+    }
+
+    @Test
+    void malformedFileReportsParseErrorInsteadOfThrowing() {
+        MockMultipartFile bad = new MockMultipartFile("file", "bad.xml", "application/xml",
+                "<tournament><not-closed>".getBytes());
+
+        ValidationReportDTO report = validationService.validate(bad);
+
+        assertFalse(report.isValid());
+        assertTrue(report.getFindings().stream().anyMatch(f -> "PARSE_ERROR".equals(f.code())),
+                "Malformed XML should yield a PARSE_ERROR finding, not a thrown exception");
+    }
+
+    @Test
+    void emptyFileReportsEmptyFile() {
+        MockMultipartFile empty = new MockMultipartFile("file", "empty.xml", "application/xml", new byte[0]);
+
+        ValidationReportDTO report = validationService.validate(empty);
+
+        assertFalse(report.isValid());
+        assertTrue(report.getFindings().stream().anyMatch(f -> "EMPTY_FILE".equals(f.code())));
+    }
+
+    @Test
+    void crossChecksFlagAlreadyImportedTournamentAndDebaters() throws Exception {
+        // Import the tournament, then validate the same file: the read-only DB cross-checks should fire.
+        importService.importTournament(TestFixtures.TOURNAMENT_1_XML);
+
+        ValidationReportDTO report = validationService.validate(fileFrom(TestFixtures.TOURNAMENT_1_XML));
+
+        assertTrue(report.getFindings().stream().anyMatch(f -> "TOURNAMENT_EXISTS".equals(f.code())),
+                "Re-validating an imported tournament should warn that it already exists");
+        assertTrue(report.getFindings().stream().anyMatch(f -> "DEBATER_EXISTS".equals(f.code())),
+                "Speakers already in the DB should be flagged as existing");
+    }
+}

--- a/src/test/java/com/dineth/debateTracker/TournamentValidationServiceTest.java
+++ b/src/test/java/com/dineth/debateTracker/TournamentValidationServiceTest.java
@@ -74,5 +74,12 @@ class TournamentValidationServiceTest {
                 "Re-validating an imported tournament should warn that it already exists");
         assertTrue(report.getFindings().stream().anyMatch(f -> "DEBATER_EXISTS".equals(f.code())),
                 "Speakers already in the DB should be flagged as existing");
+
+        // The disambiguating context (existing debater's teams) must be attached so a human can
+        // tell apart speakers with the same/misspelled/last-name-less names.
+        assertTrue(report.getFindings().stream()
+                        .filter(f -> "DEBATER_EXISTS".equals(f.code()))
+                        .anyMatch(f -> !f.matches().isEmpty() && f.matches().stream().anyMatch(m -> !m.teams().isEmpty())),
+                "A DEBATER_EXISTS finding should carry the existing debater's team context");
     }
 }


### PR DESCRIPTION
This pull request introduces a comprehensive dry-run validation feature for tournament XML uploads, allowing users to preview potential issues before importing data. It adds a new `TournamentValidationService` that performs both intrinsic XML checks and read-only database cross-checks, surfacing findings such as missing names, ambiguous debater matches, ballot mismatches, and institution reuse. The API is extended with a new `/api/v1/tournament/validate` endpoint, and supporting DTOs for detailed validation reporting are included.

**New dry-run validation pipeline:**

* Added `TournamentValidationService` as a read-only service to validate uploaded Tabbycat XML files, returning a structured `ValidationReportDTO` of findings (e.g., missing/single-word names, ballot-count mismatches, empty teams, ambiguous debater matches, and institution reuse) without persisting any data. The service never throws on bad files, instead reporting parse errors as findings.

* Extended the API in `TournamentBuilder` with a `POST /api/v1/tournament/validate` endpoint, which accepts a multipart XML file and returns the validation report. The controller now delegates to both import and validation services. [[1]](diffhunk://#diff-2c49753ccca2b3e87cfe45cd094aa4fc7f257332972e412a0f1aa097cf683c37R38-R57) [[2]](diffhunk://#diff-2c49753ccca2b3e87cfe45cd094aa4fc7f257332972e412a0f1aa097cf683c37R6-R13)

**Supporting DTOs and enums for validation reporting:**

* Introduced `DebaterMatch` and `InstitutionMatch` DTOs to provide identifying context in validation findings, helping users distinguish between similarly named debaters or institutions. [[1]](diffhunk://#diff-ff53cc0d16a5659eec8cdf7ff8743bd8dc17c015a18d3b9d61df38fca7a6bb97R1-R17) [[2]](diffhunk://#diff-920491997d2fdc8fa2504a678b6b0e7603331b6f0f327bf4e0f7e2d9c563a65dR1-R14)

* Added a `Severity` enum to classify validation findings as `ERROR`, `WARNING`, or `INFO`.

**Database query enhancements:**

* Added a `findDebatersByName` method to `DebaterService` to retrieve all debaters matching a given name, supporting ambiguity reporting in validation.

**Documentation updates:**

* Updated `AGENTS.md` to document the new validation service, endpoint, and its role in the import pipeline. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L70-R72) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R97-R98)